### PR TITLE
hotfix: revert back to using ESM dayjs exports

### DIFF
--- a/src/dayjs.js
+++ b/src/dayjs.js
@@ -1,5 +1,5 @@
-import dayjs from "dayjs";
-import relativeTime from "dayjs/plugin/relativeTime.js";
+import dayjs from "dayjs/esm";
+import relativeTime from "dayjs/esm/plugin/relativeTime";
 
 dayjs.extend(relativeTime);
 


### PR DESCRIPTION
This reverts https://github.com/metonym/svelte-time/pull/13/commits/fdba93a4e55e23cdb62fd8173a181f9dddcac971 from #13.

Unfortunately, v0.6.2 still causes dev/build issues.

User @imbolc kindly [pointed out](https://github.com/metonym/svelte-time/issues/9#issuecomment-1126965999) that this is a known issue with dayjs.

The next step would be to try using `dayjs` v2 in this component library and publish it using the next tag.