### PR TITLE
fix(action): custom live interval should update, set `datetime` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ To customize the interval, pass a value to `live` in milliseconds (ms).
 
 Use the `svelteTime` action to format a timestamp in a raw HTML element.
 
-<!-- prettier-ignore-start -->
 ```svelte
 <script>
   import { svelteTime } from "svelte-time";
@@ -127,64 +126,55 @@ Use the `svelteTime` action to format a timestamp in a raw HTML element.
 <time use:svelteTime />
 
 <time
-  use:svelteTime="{{
+  use:svelteTime={{
     timestamp: "2021-02-02",
     format: "dddd @ h:mm A · MMMM D, YYYY",
-  }}"
+  }}
 />
 
 <time
-  use:svelteTime="{{
+  use:svelteTime={{
     relative: true,
     timestamp: "2021-02-02",
-  }}"
+  }}
 />
 
 <time
-  use:svelteTime="{{
+  use:svelteTime={{
     relative: true,
     timestamp: "2021-02-02",
     format: "dddd @ h:mm A · MMMM D, YYYY",
-  }}"
+  }}
 />
-
 ```
-<!-- prettier-ignore-end -->
 
 Similar to the `Time` component, the `live` prop only works with relative time.
 
-<!-- prettier-ignore-start -->
 ```svelte
 <time
-  use:svelteTime="{{
+  use:svelteTime={{
     relative: true,
     live: true,
-  }}"
+  }}
 />
-
 ```
-<!-- prettier-ignore-end -->
 
 Specify a custom update interval using the `live` prop.
 
-<!-- prettier-ignore-start -->
 ```svelte
 <time
-  use:svelteTime="{{
+  use:svelteTime={{
     relative: true,
     live: 30 * 1_000, // update every 30 seconds
-  }}"
+  }}
 />
-
 ```
-<!-- prettier-ignore-end -->
 
 ### Custom locale
 
 Load a custom locale and set it as the default locale using the [dayjs.locale API](https://day.js.org/docs/en/i18n/changing-locale).
 
-<!-- prettier-ignore-start -->
-```html
+```svelte
 <script context="module">
   import "dayjs/esm/locale/de";
   import dayjs from "dayjs/esm";
@@ -198,7 +188,6 @@ Load a custom locale and set it as the default locale using the [dayjs.locale AP
 
 <Time />
 ```
-<!-- prettier-ignore-end -->
 
 ### `dayjs` export
 

--- a/README.md
+++ b/README.md
@@ -157,8 +157,22 @@ Similar to the `Time` component, the `live` prop only works with relative time.
 ```svelte
 <time
   use:svelteTime="{{
-    live: true,
     relative: true,
+    live: true,
+  }}"
+/>
+
+```
+<!-- prettier-ignore-end -->
+
+Specify a custom update interval using the `live` prop.
+
+<!-- prettier-ignore-start -->
+```svelte
+<time
+  use:svelteTime="{{
+    relative: true,
+    live: 30 * 1_000, // update every 30 seconds
   }}"
 />
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "rollup -cw",
     "predeploy": "rollup -c",
     "deploy": "gh-pages -d dist",
-    "format": "prettier --ignore-path .gitignore --write '**/*.{js,ts,svelte}'",
+    "format": "prettier --ignore-path .gitignore --write '**/*.{md,js,ts,svelte}'",
     "check": "svelte-check --workspace tests",
     "test": "vitest"
   },

--- a/src/svelte-time.js
+++ b/src/svelte-time.js
@@ -28,6 +28,7 @@ export function svelteTime(node, options = {}) {
       }
     }
 
+    node.setAttribute("datetime", timestamp);
     node.innerText = relative ? formatted_from : formatted;
   }
 

--- a/src/svelte-time.js
+++ b/src/svelte-time.js
@@ -13,11 +13,13 @@ export function svelteTime(node, options = {}) {
     const timestamp = options.timestamp || new Date().toISOString();
     const format = options.format || "MMM DD, YYYY";
     const relative = options.relative === true;
-    const live = options.live === true;
-    const formatted = relative ? dayjs(timestamp).from() : dayjs(timestamp).format(format);
+    const live = options.live ?? false;
+
+    let formatted_from = dayjs(timestamp).from();
+    let formatted = dayjs(timestamp).format(format);
 
     if (relative) {
-      node.setAttribute("title", dayjs(timestamp).format(format));
+      node.setAttribute("title", formatted);
 
       if (live !== false) {
         interval = setInterval(() => {
@@ -26,7 +28,7 @@ export function svelteTime(node, options = {}) {
       }
     }
 
-    node.innerText = formatted;
+    node.innerText = relative ? formatted_from : formatted;
   }
 
   setTime(node, options);

--- a/tests/SvelteTime.test.js
+++ b/tests/SvelteTime.test.js
@@ -28,53 +28,76 @@ describe("svelte-time", () => {
       target,
     });
 
+    const date = new Date();
+    const timestamp = date.toISOString();
+
     const defaultComponent = target.querySelector('[data-test="default"]');
     expect(defaultComponent.innerHTML).toEqual(DEFAULT_TIME);
     expect(defaultComponent.innerHTML).toEqual(dayjs().format("MMM DD, YYYY"));
 
     const timestampString = target.querySelector('[data-test="timestamp-string"]');
     expect(timestampString.innerHTML).toEqual("Feb 01, 2020");
+    expect(timestampString.getAttribute("datetime")).toEqual("2020-02-01");
 
     const timestampDate = target.querySelector('[data-test="timestamp-date"]');
-    expect(timestampDate.innerHTML).toEqual(dayjs(new Date()).format("dddd @ h:mm a"));
+    expect(timestampDate.innerHTML).toEqual(dayjs(date).format("dddd @ h:mm a"));
+    expect(timestampDate.getAttribute("datetime")).toEqual(date + "");
 
     const timestampNumber = target.querySelector('[data-test="timestamp-number"]');
     expect(timestampNumber.innerHTML).toEqual(dayjs(1e10).format("dddd @ h:mm A · MMMM D, YYYY"));
+    expect(timestampNumber.getAttribute("datetime")).toEqual(1e10 + "");
 
     const relative = target.querySelector('[data-test="relative"]');
     expect(relative.innerHTML).toEqual("a few seconds ago");
+    expect(relative.getAttribute("datetime")).toEqual(timestamp);
 
     const relativeTimestamp = target.querySelector('[data-test="relative-timestamp"]');
     expect(relativeTimestamp.innerHTML).toEqual("a year ago");
+    expect(relativeTimestamp.getAttribute("datetime")).toEqual("2021-02-02");
 
     const relativeTimestampNumber = target.querySelector('[data-test="relative-timestamp-number"]');
     expect(relativeTimestampNumber.innerHTML).toEqual("52 years ago");
+    expect(relativeTimestampNumber.getAttribute("datetime")).toEqual(1e10 + "");
 
     const relativeLive = target.querySelector('[data-test="relative-live"]');
     const actionRelativeLive = target.querySelector('[data-test="action-relative-live"]');
 
+    expect(relativeLive.title).toEqual(DEFAULT_TIME);
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
     expect(relativeLive.innerHTML).toEqual("a few seconds ago");
     expect(actionRelativeLive.innerText).toEqual("a few seconds ago");
+    expect(relativeLive.getAttribute("datetime")).toEqual(timestamp);
+    expect(actionRelativeLive.getAttribute("datetime")).toEqual(timestamp);
 
     vi.runOnlyPendingTimers();
     await tick();
+    expect(relativeLive.title).toEqual(DEFAULT_TIME);
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
     expect(relativeLive.innerHTML).toEqual("a minute ago");
     expect(actionRelativeLive.innerText).toEqual("a minute ago");
     expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
+    expect(relativeLive.getAttribute("datetime")).toEqual(timestamp);
+    expect(actionRelativeLive.getAttribute("datetime")).toEqual(timestamp);
 
     vi.runOnlyPendingTimers();
     await tick();
+    expect(relativeLive.title).toEqual(DEFAULT_TIME);
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
     expect(relativeLive.innerHTML).toEqual("2 minutes ago");
     expect(actionRelativeLive.innerText).toEqual("2 minutes ago");
     expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
+    expect(relativeLive.getAttribute("datetime")).toEqual(timestamp);
+    expect(actionRelativeLive.getAttribute("datetime")).toEqual(timestamp);
 
     const action = target.querySelector('[data-test="action"]');
     expect(action.innerText).toEqual(DEFAULT_TIME);
+    expect(action.getAttribute("datetime")).toEqual(timestamp);
 
     const actionTimestampFormat = target.querySelector('[data-test="action-timestamp-format"]');
     expect(actionTimestampFormat.innerText).toEqual(
       dayjs("2021-02-02").format("dddd @ h:mm A · MMMM D, YYYY")
     );
+    expect(actionTimestampFormat.getAttribute("datetime")).toEqual("2021-02-02");
 
     const dayjsOnly = target.querySelector('[data-test="dayjs"]');
     expect(dayjsOnly.innerHTML).toEqual(DEFAULT_TIME);
@@ -87,6 +110,9 @@ describe("svelte-time", () => {
       target,
     });
 
+    const date = new Date();
+    const timestamp = date.toISOString();
+
     const relativeLive = target.querySelector('[data-test="relative-live"]');
     const actionRelativeLive = target.querySelector('[data-test="action-relative-live"]');
 
@@ -94,6 +120,8 @@ describe("svelte-time", () => {
     expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
     expect(relativeLive.innerHTML).toEqual("a few seconds ago");
     expect(actionRelativeLive.innerText).toEqual("a few seconds ago");
+    expect(relativeLive.getAttribute("datetime")).toEqual(timestamp);
+    expect(actionRelativeLive.getAttribute("datetime")).toEqual(timestamp);
 
     vi.runOnlyPendingTimers();
     await tick();
@@ -101,6 +129,8 @@ describe("svelte-time", () => {
     expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
     expect(relativeLive.innerHTML).toEqual("a minute ago");
     expect(actionRelativeLive.innerText).toEqual("a minute ago");
+    expect(relativeLive.getAttribute("datetime")).toEqual(timestamp);
+    expect(actionRelativeLive.getAttribute("datetime")).toEqual(timestamp);
 
     vi.runOnlyPendingTimers();
     await tick();
@@ -108,6 +138,8 @@ describe("svelte-time", () => {
     expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
     expect(relativeLive.innerHTML).toEqual("2 minutes ago");
     expect(actionRelativeLive.innerText).toEqual("2 minutes ago");
+    expect(relativeLive.getAttribute("datetime")).toEqual(timestamp);
+    expect(actionRelativeLive.getAttribute("datetime")).toEqual(timestamp);
   });
 
   test("exported dayjs", () => {

--- a/tests/SvelteTime.test.js
+++ b/tests/SvelteTime.test.js
@@ -1,9 +1,13 @@
 import { test, expect, describe, afterEach, vi } from "vitest";
 import dayjs from "dayjs";
-import SvelteTime from "./SvelteTime.test.svelte";
 import { tick } from "svelte";
+import { dayjs as dayjsExported } from "../src";
+import SvelteTime from "./SvelteTime.test.svelte";
+import SvelteTimeLive from "./SvelteTimeLive.test.svelte";
 
 describe("svelte-time", () => {
+  const DEFAULT_TIME = dayjs(new Date().toISOString()).format("MMM DD, YYYY");
+
   let instance = null;
 
   beforeEach(() => {
@@ -23,8 +27,6 @@ describe("svelte-time", () => {
     instance = new SvelteTime({
       target,
     });
-
-    const DEFAULT_TIME = dayjs(new Date().toISOString()).format("MMM DD, YYYY");
 
     const defaultComponent = target.querySelector('[data-test="default"]');
     expect(defaultComponent.innerHTML).toEqual(DEFAULT_TIME);
@@ -58,11 +60,13 @@ describe("svelte-time", () => {
     await tick();
     expect(relativeLive.innerHTML).toEqual("a minute ago");
     expect(actionRelativeLive.innerText).toEqual("a minute ago");
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
 
     vi.runOnlyPendingTimers();
     await tick();
     expect(relativeLive.innerHTML).toEqual("2 minutes ago");
     expect(actionRelativeLive.innerText).toEqual("2 minutes ago");
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
 
     const action = target.querySelector('[data-test="action"]');
     expect(action.innerText).toEqual(DEFAULT_TIME);
@@ -74,5 +78,39 @@ describe("svelte-time", () => {
 
     const dayjsOnly = target.querySelector('[data-test="dayjs"]');
     expect(dayjsOnly.innerHTML).toEqual(DEFAULT_TIME);
+  });
+
+  test("SvelteTimeLive.test.svelte", async () => {
+    const target = document.body;
+
+    instance = new SvelteTimeLive({
+      target,
+    });
+
+    const relativeLive = target.querySelector('[data-test="relative-live"]');
+    const actionRelativeLive = target.querySelector('[data-test="action-relative-live"]');
+
+    expect(relativeLive.title).toEqual(DEFAULT_TIME);
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
+    expect(relativeLive.innerHTML).toEqual("a few seconds ago");
+    expect(actionRelativeLive.innerText).toEqual("a few seconds ago");
+
+    vi.runOnlyPendingTimers();
+    await tick();
+    expect(relativeLive.title).toEqual(DEFAULT_TIME);
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
+    expect(relativeLive.innerHTML).toEqual("a minute ago");
+    expect(actionRelativeLive.innerText).toEqual("a minute ago");
+
+    vi.runOnlyPendingTimers();
+    await tick();
+    expect(relativeLive.title).toEqual(DEFAULT_TIME);
+    expect(actionRelativeLive.title).toEqual(DEFAULT_TIME);
+    expect(relativeLive.innerHTML).toEqual("2 minutes ago");
+    expect(actionRelativeLive.innerText).toEqual("2 minutes ago");
+  });
+
+  test("exported dayjs", () => {
+    expect(dayjsExported().from()).toEqual("a few seconds ago");
   });
 });

--- a/tests/SvelteTimeLive.test.svelte
+++ b/tests/SvelteTimeLive.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Time, { svelteTime } from "../src";
+
+  const CUSTOM_INTERVAL = 30 * 1_000;
+</script>
+
+<Time data-test="relative-live" relative live={CUSTOM_INTERVAL} />
+
+<time
+  data-test="action-relative-live"
+  use:svelteTime={{
+    relative: true,
+    live: CUSTOM_INTERVAL,
+  }}
+/>


### PR DESCRIPTION
**Fixes**

- `svelteTime` action should update the time if provided a custom live interval
- `svelteTime` action should set the `datetime` attribute using the provided `timestamp`