### PR TITLE
fix(dayjs): use CJS instead of ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-time",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "description": "Svelte component and action to format a timestamp using day.js",
   "author": "Eric Liu (https://github.com/metonym)",

--- a/src/dayjs.js
+++ b/src/dayjs.js
@@ -1,5 +1,5 @@
-import dayjs from "dayjs/esm";
-import relativeTime from "dayjs/esm/plugin/relativeTime";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime.js";
 
 dayjs.extend(relativeTime);
 


### PR DESCRIPTION
This is actually a second attempt at https://github.com/metonym/svelte-time/pull/13.

It uses the CJS build for `dayjs`, so vite/SvelteKit can optimize the dependency. The reason #13 was reverted because it stopped working with Snowpack.

I'll publish this under a `next` tag and play around with it. Even if it does break Snowpack, I think it's more important to unblock vite/SvelteKit usage.