### PR TITLE
chore: add `exports` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "svelte": "./src/index.js",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    },
+    "./src/*": "./src/*"
+  },
   "scripts": {
     "dev": "rollup -cw",
     "format": "prettier --ignore-path .gitignore --write .",

--- a/tests/SvelteTime.test.ts
+++ b/tests/SvelteTime.test.ts
@@ -1,7 +1,7 @@
 import dayjs from "dayjs";
 import { SvelteComponent, tick } from "svelte";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { dayjs as dayjsExported } from "svelte-time";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import SvelteTime from "./SvelteTime.test.svelte";
 import SvelteTimeLive from "./SvelteTimeLive.test.svelte";
 
@@ -69,7 +69,7 @@ describe("svelte-time", () => {
     const relativeTimestampNumber = target.querySelector(
       '[data-test="relative-timestamp-number"]',
     )!;
-    expect(relativeTimestampNumber.innerHTML).toEqual("53 years ago");
+    expect(relativeTimestampNumber.innerHTML).toEqual("54 years ago");
     expect(relativeTimestampNumber.getAttribute("datetime")).toEqual(1e10 + "");
 
     const relativeLive = target.querySelector(


### PR DESCRIPTION
Closes #35 

Add an `exports` map since the `svelte` entry point is deprecated.