### PR TITLE
fix(package): includes paths for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,18 @@
   "types": "./src/index.d.ts",
   "exports": {
     ".": {
-      "svelte": "./src/index.js"
+      "types": "./src/index.d.ts",
+      "svelte": "./src/index.js",
+      "default": "./src/index.js"
     },
-    "./src/*": "./src/*"
+    "./src/*.svelte": {
+      "types": "./src/*.svelte.d.ts",
+      "import": "./src/*.svelte"
+    },
+    "./src/*": {
+      "types": "./src/*.d.ts",
+      "import": "./src/*.js"
+    }
   },
   "scripts": {
     "dev": "rollup -cw",


### PR DESCRIPTION
Fixes #35

Two issues:

- Path resolutions for types must be included.
- *.svelte and *.js inside `./src/` must also have explicit paths for types/imports