### PR TITLE
fix(types): fix `svelteTime` import

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,3 @@
 export { dayjs } from "./dayjs";
-export { svelteTime } from "./svelte-time";
+export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";


### PR DESCRIPTION
The `svelteTime` action is missing the file extension in the barrel file export.