### PR TITLE
fix(time): `formatted` is reactive

### DIFF
--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -34,13 +34,15 @@
 
   const DEFAULT_INTERVAL = 60 * 1_000;
 
+  let tick = $state(0);
+
   $effect(() => {
     /** @type {undefined | NodeJS.Timeout} */
     let interval;
     if (relative && live !== false) {
       interval = setInterval(
         () => {
-          formatted = dayjs(timestamp).from();
+          tick++;
         },
         Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
       );
@@ -53,9 +55,10 @@
    * Result of invoking `dayjs().format()`
    * @type {string}
    */
-  let formatted = $state(
-    relative ? dayjs(timestamp).from() : dayjs(timestamp).format(format),
-  );
+  let formatted = $derived.by(() => {
+    tick;
+    return relative ? dayjs(timestamp).from() : dayjs(timestamp).format(format);
+  });
 
   const title = $derived(
     relative ? dayjs(timestamp).format(format) : undefined,

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -11,15 +11,17 @@ export const svelteTime = (node, options = {}) => {
   /** @type {undefined | NodeJS.Timeout} */
   let interval = undefined;
 
-  /** @type {SvelteTimeAction} */
-  const setTime = (node, options = {}) => {
+  const updateTime = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+
     const timestamp = options.timestamp || new Date().toISOString();
     const format = options.format || "MMM DD, YYYY";
     const relative = options.relative === true;
     const live = options.live ?? false;
 
-    let formatted_from = dayjs(timestamp).from();
-    let formatted = dayjs(timestamp).format(format);
+    const formatted_from = dayjs(timestamp).from();
+    const formatted = dayjs(timestamp).format(format);
 
     if (relative) {
       if ("title" in options) {
@@ -38,17 +40,20 @@ export const svelteTime = (node, options = {}) => {
           Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
         );
       }
+    } else {
+      node.removeAttribute("title");
     }
 
     node.setAttribute("datetime", timestamp);
     node.innerText = relative ? formatted_from : formatted;
   };
 
-  $effect(() => {
-    setTime(node, options);
+  updateTime(options);
 
-    return () => {
+  return {
+    update: updateTime,
+    destroy() {
       clearInterval(interval);
-    };
-  });
+    },
+  };
 };

--- a/tests/SvelteTimeAction.test.ts
+++ b/tests/SvelteTimeAction.test.ts
@@ -81,4 +81,28 @@ describe("svelte-time-action", () => {
     // The action should preserve the original element structure
     expect(timeElement.children.length).toBe(0);
   });
+
+  // Regression test for https://github.com/metonym/svelte-time/issues/66
+  test("updates when timestamp changes (reactivity)", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeAction, { target });
+    flushSync();
+
+    const timeElement = getElement("time");
+    const initialFormattedDate = dayjs("2021-02-02").format(
+      "dddd @ h:mm A · MMMM D, YYYY",
+    );
+    expect(timeElement.innerText).toEqual(initialFormattedDate);
+    expect(timeElement.getAttribute("datetime")).toEqual("2021-02-02");
+
+    const button = getElement("button");
+    button.click();
+    flushSync();
+
+    const updatedFormattedDate = dayjs("2022-02-02").format(
+      "dddd @ h:mm A · MMMM D, YYYY",
+    );
+    expect(timeElement.innerText).toEqual(updatedFormattedDate);
+    expect(timeElement.getAttribute("datetime")).toEqual("2022-02-02");
+  });
 });

--- a/tests/SvelteTimeReactive.test.ts
+++ b/tests/SvelteTimeReactive.test.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { flushSync, mount, tick, unmount } from "svelte";
 import SvelteTimeReactive from "./SvelteTimeReactive.test.svelte";
 
-describe.skip("svelte-time-reactive", () => {
+describe("svelte-time-reactive", () => {
   let instance: null | ReturnType<typeof mount> = null;
   const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
 


### PR DESCRIPTION
Fixes #66

In v2 (Runes mode), the `formatted` value in the `Time` component and the `svelteTime` action lost reactivity when props changed. This was a regression from v1 where these values were reactive.

**Expected behavior:** When `timestamp`, `format`, or `relative` props change, the displayed time should update automatically.

**Actual behavior:** The formatted time was only calculated once on initialization and never updated when props changed.

---

This PR implements the following fixes:

- `Time.svelte`: Changed `formatted` from `$state` to `$derived.by()`. Since `dayjs().from()` doesn't automatically track time passing for live updates, introduced a tick state variable that increments on intervals to force recalculation.
- `svelte-time.svelte.js`: Replaced the `$effect` approach with proper Svelte action pattern using `update()` and `destroy()` methods. Actions don't automatically track parameter changes through `$effect`—they require explicit `update()` callbacks.


Added reactivity tests and verified all 33 tests pass, including:
- 4 reactive tests for the `Time` component  
- 1 new reactivity test for the action
- Verified the action example in the docs updates correctly