### PR TITLE
feat: support duration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-time",
   "version": "2.1.0",
   "license": "MIT",
-  "description": "Svelte component and action to format a timestamp using day.js",
+  "description": "Svelte library for formatting timestamps and durations using day.js",
   "author": "Eric Liu (https://github.com/metonym)",
   "type": "module",
   "svelte": "./src/index.js",
@@ -47,7 +47,9 @@
     "time formatter",
     "timestamp",
     "relative",
-    "ago"
+    "ago",
+    "duration",
+    "timer"
   ],
   "prettier": {
     "plugins": [

--- a/src/Duration.svelte
+++ b/src/Duration.svelte
@@ -1,0 +1,126 @@
+<script>
+  const {
+    /**
+     * Duration value in milliseconds, or a dayjs Duration object
+     * @type {number | import("dayjs").Duration}
+     */
+    value = 0,
+
+    /**
+     * Unit for the duration value (only used when value is a number)
+     * @type {"milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"}
+     */
+    unit = "milliseconds",
+
+    /**
+     * Format for display. If not provided and humanize is false, displays raw milliseconds.
+     * @type {string | undefined}
+     * @example "HH:mm:ss"
+     */
+    format,
+
+    /**
+     * Set to `true` to display the duration in a human-readable format (e.g., "2 hours", "a minute")
+     * @type {boolean}
+     */
+    humanize = false,
+
+    /**
+     * The locale to use for formatting
+     * @type {import("./locales").Locales}
+     */
+    locale = "en",
+
+    /**
+     * Set to `true` to update the duration at specified interval (for countdown/countup)
+     * Pass in a number (ms) to specify the interval length
+     * @type {boolean | number}
+     */
+    live = false,
+    ...rest
+  } = $props();
+
+  import { dayjs } from "./dayjs-duration";
+
+  const DEFAULT_INTERVAL = 60 * 1_000;
+
+  let tick = $state(0);
+
+  $effect(() => {
+    /** @type {undefined | NodeJS.Timeout} */
+    let interval;
+    if (live !== false) {
+      interval = setInterval(
+        () => {
+          tick++;
+        },
+        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
+      );
+    }
+    return () => clearInterval(interval);
+  });
+
+  /**
+   * Get the duration object from the value prop
+   */
+  const durationObj = $derived.by(() => {
+    tick; // React to tick changes for live updates
+    if (typeof value === "number") {
+      return dayjs.duration(value, unit);
+    }
+    // value is already a dayjs Duration object
+    return value;
+  });
+
+  /**
+   * Formatted duration string
+   */
+  const formatted = $derived.by(() => {
+    const duration = durationObj;
+    if (format) {
+      // Use custom format (e.g., "HH:mm:ss", "mm:ss")
+      const totalSeconds = Math.floor(duration.asSeconds());
+      const hasHours = /H/.test(format);
+      const hours = Math.floor(totalSeconds / 3600);
+      // If format doesn't include hours, use total minutes; otherwise use minutes after hours
+      const minutes = hasHours
+        ? Math.floor((totalSeconds % 3600) / 60)
+        : Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      const ms = duration.milliseconds() % 1000;
+
+      // Replace in order: longest patterns first to avoid partial matches
+      return format
+        .replace(/HHH/g, String(hours).padStart(3, "0"))
+        .replace(/HH/g, String(hours).padStart(2, "0"))
+        .replace(/H/g, String(hours))
+        .replace(/mmm/g, String(minutes).padStart(3, "0"))
+        .replace(/mm/g, String(minutes).padStart(2, "0"))
+        .replace(/m/g, String(minutes))
+        .replace(/sss/g, String(seconds).padStart(3, "0"))
+        .replace(/ss/g, String(seconds).padStart(2, "0"))
+        .replace(/s/g, String(seconds))
+        .replace(/SSSS/g, String(ms).padStart(4, "0"))
+        .replace(/SSS/g, String(ms).padStart(3, "0"))
+        .replace(/SS/g, String(ms).padStart(2, "0"))
+        .replace(/S/g, String(ms));
+    } else if (humanize) {
+      // Use human-readable format with locale
+      return duration.locale(locale).humanize();
+    } else {
+      // Fallback: return duration in milliseconds
+      return String(duration.asMilliseconds());
+    }
+  });
+
+  /**
+   * ISO 8601 duration string for the datetime attribute
+   */
+  const datetime = $derived.by(() => {
+    return durationObj.toISOString();
+  });
+</script>
+
+<time {datetime} {...rest}>
+  {formatted}
+</time>

--- a/src/Duration.svelte.d.ts
+++ b/src/Duration.svelte.d.ts
@@ -1,0 +1,60 @@
+import type { Component } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { Locales } from "./locales";
+
+type RestProps = SvelteHTMLElements["time"];
+
+type DayjsDuration = ReturnType<typeof import("./dayjs").dayjs.duration>;
+
+export interface DurationProps extends RestProps {
+  /**
+   * Duration value in milliseconds, or a dayjs Duration object
+   * @default 0
+   */
+  value?: number | DayjsDuration;
+
+  /**
+   * Unit for the duration value (only used when value is a number)
+   * @default "milliseconds"
+   */
+  unit?:
+    | "milliseconds"
+    | "seconds"
+    | "minutes"
+    | "hours"
+    | "days"
+    | "weeks"
+    | "months"
+    | "years";
+
+  /**
+   * Format for display. If not provided and humanize is false, displays raw milliseconds.
+   * @example "HH:mm:ss"
+   */
+  format?: string;
+
+  /**
+   * Set to `true` to display the duration in a human-readable format (e.g., "2 hours", "a minute")
+   * @default false
+   */
+  humanize?: boolean;
+
+  /**
+   * The locale to use for formatting
+   * @default "en"
+   */
+  locale?: Locales;
+
+  /**
+   * Set to `true` to update the duration at specified interval (for countdown/countup)
+   * Pass in a number (ms) to specify the interval length
+   * @default false
+   */
+  live?: boolean | number;
+
+  [key: `data-${string}`]: any;
+}
+
+declare const Duration: Component<DurationProps>;
+
+export default Duration;

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -43,7 +43,7 @@
     ...rest
   } = $props();
 
-  import { dayjs } from "./dayjs";
+  import { dayjs } from "./dayjs-time";
 
   const DEFAULT_INTERVAL = 60 * 1_000;
 

--- a/src/dayjs-duration.js
+++ b/src/dayjs-duration.js
@@ -1,0 +1,6 @@
+import { dayjs } from "./dayjs";
+import duration from "dayjs/plugin/duration.js";
+
+dayjs.extend(duration);
+
+export { dayjs };

--- a/src/dayjs-duration.ts
+++ b/src/dayjs-duration.ts
@@ -1,0 +1,6 @@
+import { dayjs } from "./dayjs";
+import duration from "dayjs/esm/plugin/duration";
+
+dayjs.extend(duration);
+
+export { dayjs };

--- a/src/dayjs-time.js
+++ b/src/dayjs-time.js
@@ -1,8 +1,6 @@
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime.js";
-import duration from "dayjs/plugin/duration.js";
 
 dayjs.extend(relativeTime);
-dayjs.extend(duration);
 
 export { dayjs };

--- a/src/dayjs-time.ts
+++ b/src/dayjs-time.ts
@@ -1,8 +1,6 @@
 import dayjs from "dayjs/esm";
 import relativeTime from "dayjs/esm/plugin/relativeTime";
-import duration from "dayjs/esm/plugin/duration";
 
 dayjs.extend(relativeTime);
-dayjs.extend(duration);
 
 export { dayjs };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,6 @@
 export { dayjs } from "./dayjs";
 export { svelteTime } from "./svelte-time.svelte";
+export { svelteDuration } from "./svelte-duration.svelte";
 export { default } from "./Time.svelte";
+export { default as Duration } from "./Duration.svelte";
 export type { Locales } from "./locales";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 export { dayjs } from "./dayjs";
 export { svelteTime } from "./svelte-time.svelte";
+export { svelteDuration } from "./svelte-duration.svelte";
 export { default } from "./Time.svelte";
+export { default as Duration } from "./Duration.svelte";

--- a/src/svelte-duration.svelte.d.ts
+++ b/src/svelte-duration.svelte.d.ts
@@ -1,0 +1,12 @@
+import type { Action } from "svelte/action";
+import type { DurationProps } from "./Duration.svelte";
+
+export interface SvelteDurationOptions extends Pick<
+  DurationProps,
+  "value" | "unit" | "format" | "humanize" | "locale" | "live"
+> {}
+
+export const svelteDuration: Action<
+  HTMLElement,
+  undefined | Partial<SvelteDurationOptions>
+>;

--- a/src/svelte-duration.svelte.js
+++ b/src/svelte-duration.svelte.js
@@ -1,0 +1,138 @@
+import { dayjs } from "./dayjs-duration";
+
+/**
+ * @typedef {import("./svelte-duration.svelte").SvelteDurationOptions} SvelteDurationOptions
+ * @typedef {import ("svelte/action").Action<HTMLElement, Partial<SvelteDurationOptions>>} SvelteDurationAction
+ * @type {SvelteDurationAction}
+ */
+export const svelteDuration = (node, options = {}) => {
+  const DEFAULT_INTERVAL = 60 * 1_000;
+
+  /** @type {undefined | NodeJS.Timeout} */
+  let interval = undefined;
+
+  const updateDuration = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+
+    const value = options.value ?? 0;
+    const unit = options.unit ?? "milliseconds";
+    const format = options.format;
+    const humanize = options.humanize ?? false;
+    const locale = options.locale ?? "en";
+    const live = options.live ?? false;
+
+    let duration;
+    if (typeof value === "number") {
+      duration = dayjs.duration(value, unit);
+    } else {
+      duration = value;
+    }
+
+    let formatted;
+    if (format) {
+      // Use custom format (e.g., "HH:mm:ss", "mm:ss")
+      const totalSeconds = Math.floor(duration.asSeconds());
+      const hasHours = /H/.test(format);
+      const hours = Math.floor(totalSeconds / 3600);
+      // If format doesn't include hours, use total minutes; otherwise use minutes after hours
+      const minutes = hasHours
+        ? Math.floor((totalSeconds % 3600) / 60)
+        : Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+      const ms = duration.milliseconds() % 1000;
+
+      formatted = format
+        .replace(/HHH/g, String(hours).padStart(3, "0"))
+        .replace(/HH/g, String(hours).padStart(2, "0"))
+        .replace(/H/g, String(hours))
+        .replace(/mmm/g, String(minutes).padStart(3, "0"))
+        .replace(/mm/g, String(minutes).padStart(2, "0"))
+        .replace(/m/g, String(minutes))
+        .replace(/sss/g, String(seconds).padStart(3, "0"))
+        .replace(/ss/g, String(seconds).padStart(2, "0"))
+        .replace(/s/g, String(seconds))
+        .replace(/SSSS/g, String(ms).padStart(4, "0"))
+        .replace(/SSS/g, String(ms).padStart(3, "0"))
+        .replace(/SS/g, String(ms).padStart(2, "0"))
+        .replace(/S/g, String(ms));
+    } else if (humanize) {
+      // Use human-readable format with locale
+      formatted = duration.locale(locale).humanize();
+    } else {
+      // Fallback: return duration in milliseconds
+      formatted = String(duration.asMilliseconds());
+    }
+
+    // Set datetime attribute with ISO 8601 duration format for semantic HTML
+    if (node.tagName === "TIME") {
+      node.setAttribute("datetime", duration.toISOString());
+    }
+
+    node.innerText = formatted;
+
+    if (live !== false) {
+      interval = setInterval(
+        () => {
+          // For live updates, we need to recalculate if value is a number
+          // For duration objects, they're already fixed
+          let currentDuration;
+          if (typeof value === "number") {
+            currentDuration = dayjs.duration(value, unit);
+          } else {
+            currentDuration = value;
+          }
+
+          let currentFormatted;
+          if (format) {
+            const totalSeconds = Math.floor(currentDuration.asSeconds());
+            const hasHours = /H/.test(format);
+            const hours = Math.floor(totalSeconds / 3600);
+            // If format doesn't include hours, use total minutes; otherwise use minutes after hours
+            const minutes = hasHours
+              ? Math.floor((totalSeconds % 3600) / 60)
+              : Math.floor(totalSeconds / 60);
+            const seconds = totalSeconds % 60;
+            const ms = currentDuration.milliseconds() % 1000;
+
+            currentFormatted = format
+              .replace(/HHH/g, String(hours).padStart(3, "0"))
+              .replace(/HH/g, String(hours).padStart(2, "0"))
+              .replace(/H/g, String(hours))
+              .replace(/mmm/g, String(minutes).padStart(3, "0"))
+              .replace(/mm/g, String(minutes).padStart(2, "0"))
+              .replace(/m/g, String(minutes))
+              .replace(/sss/g, String(seconds).padStart(3, "0"))
+              .replace(/ss/g, String(seconds).padStart(2, "0"))
+              .replace(/s/g, String(seconds))
+              .replace(/SSSS/g, String(ms).padStart(4, "0"))
+              .replace(/SSS/g, String(ms).padStart(3, "0"))
+              .replace(/SS/g, String(ms).padStart(2, "0"))
+              .replace(/S/g, String(ms));
+          } else if (humanize) {
+            currentFormatted = currentDuration.locale(locale).humanize();
+          } else {
+            currentFormatted = String(currentDuration.asMilliseconds());
+          }
+
+          // Update datetime attribute for live updates
+          if (node.tagName === "TIME") {
+            node.setAttribute("datetime", currentDuration.toISOString());
+          }
+
+          node.innerText = currentFormatted;
+        },
+        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
+      );
+    }
+  };
+
+  updateDuration(options);
+
+  return {
+    update: updateDuration,
+    destroy() {
+      clearInterval(interval);
+    },
+  };
+};

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -1,4 +1,4 @@
-import { dayjs } from "./dayjs";
+import { dayjs } from "./dayjs-time";
 
 /**
  * @typedef {import("./svelte-time.svelte").SvelteTimeOptions} SvelteTimeOptions

--- a/tests/Duration.test.svelte
+++ b/tests/Duration.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { Duration, dayjs } from "svelte-time";
+</script>
+
+<!-- Basic (default: raw milliseconds) -->
+<Duration data-test="default" value={3600000} />
+<Duration data-test="value-seconds" value={90} unit="seconds" />
+<Duration
+  data-test="value-duration-object"
+  value={dayjs.duration(2, "hours")}
+/>
+
+<!-- Humanize -->
+<Duration data-test="humanize-default" value={3600000} humanize={true} />
+<Duration data-test="humanize-false-format" value={3600000} format="HH:mm:ss" />
+<Duration
+  data-test="humanize-false-format-short"
+  value={5400000}
+  format="mm:ss"
+/>
+
+<!-- Locale -->
+<Duration data-test="locale-de" value={3600000} humanize={true} locale="de" />
+<Duration data-test="locale-es" value={120000} humanize={true} locale="es" />
+
+<!-- Live updates -->
+<Duration data-test="live" value={3600000} humanize={true} live />
+<Duration
+  data-test="live-custom-interval"
+  value={3600000}
+  live={1000}
+  format="mm:ss"
+/>

--- a/tests/Duration.test.ts
+++ b/tests/Duration.test.ts
@@ -1,0 +1,141 @@
+import dayjs from "dayjs";
+import { flushSync, mount, tick, unmount } from "svelte";
+import Duration from "./Duration.test.svelte";
+
+describe("Duration", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("renders as time element with datetime attribute", () => {
+    const target = document.body;
+
+    instance = mount(Duration, { target });
+    flushSync();
+
+    // Verify element is a <time> element, not <span>
+    const defaultComponent = getElement('[data-test="default"]')!;
+    expect(defaultComponent.tagName).toEqual("TIME");
+    expect(defaultComponent.getAttribute("datetime")).toEqual("PT1H");
+
+    const valueSeconds = getElement('[data-test="value-seconds"]')!;
+    expect(valueSeconds.tagName).toEqual("TIME");
+    expect(valueSeconds.getAttribute("datetime")).toEqual("PT1M30S");
+
+    const valueDurationObject = getElement(
+      '[data-test="value-duration-object"]',
+    )!;
+    expect(valueDurationObject.tagName).toEqual("TIME");
+    expect(valueDurationObject.getAttribute("datetime")).toEqual("PT2H");
+  });
+
+  test("formats duration correctly", () => {
+    const target = document.body;
+
+    instance = mount(Duration, { target });
+    flushSync();
+
+    const defaultComponent = getElement('[data-test="default"]')!;
+    // Default behavior: raw milliseconds
+    expect(defaultComponent.innerHTML).toEqual("3600000");
+
+    const valueSeconds = getElement('[data-test="value-seconds"]')!;
+    // Default behavior: raw milliseconds (90 seconds = 90000 ms)
+    expect(valueSeconds.innerHTML).toEqual("90000");
+
+    const humanizeDefault = getElement('[data-test="humanize-default"]')!;
+    expect(humanizeDefault.innerHTML).toEqual("an hour");
+
+    const humanizeFalseFormat = getElement(
+      '[data-test="humanize-false-format"]',
+    )!;
+    expect(humanizeFalseFormat.innerHTML).toEqual("01:00:00");
+
+    const humanizeFalseFormatShort = getElement(
+      '[data-test="humanize-false-format-short"]',
+    )!;
+    expect(humanizeFalseFormatShort.innerHTML).toEqual("90:00");
+  });
+
+  test("locale formatting", async () => {
+    // Import locales before mounting
+    await import("dayjs/locale/de");
+    await import("dayjs/locale/es");
+
+    const target = document.body;
+
+    instance = mount(Duration, { target });
+    flushSync();
+
+    const localeDe = getElement('[data-test="locale-de"]')!;
+    expect(localeDe.innerHTML).toEqual("eine Stunde");
+    expect(localeDe.getAttribute("datetime")).toEqual("PT1H");
+
+    const localeEs = getElement('[data-test="locale-es"]')!;
+    expect(localeEs.innerHTML).toEqual("2 minutos");
+    expect(localeEs.getAttribute("datetime")).toEqual("PT2M");
+  });
+
+  test("live updates", async () => {
+    const target = document.body;
+
+    instance = mount(Duration, { target });
+    flushSync();
+
+    const live = getElement('[data-test="live"]')!;
+    expect(live.tagName).toEqual("TIME");
+    expect(live.getAttribute("datetime")).toEqual("PT1H");
+    expect(live.innerHTML).toEqual("an hour");
+
+    // Advance time by 60 seconds (default interval)
+    vi.advanceTimersByTime(60 * 1000);
+    await tick();
+    expect(live.getAttribute("datetime")).toEqual("PT1H");
+    expect(live.innerHTML).toEqual("an hour");
+
+    const liveCustomInterval = getElement(
+      '[data-test="live-custom-interval"]',
+    )!;
+    expect(liveCustomInterval.tagName).toEqual("TIME");
+    expect(liveCustomInterval.getAttribute("datetime")).toEqual("PT1H");
+    expect(liveCustomInterval.innerHTML).toEqual("60:00");
+
+    // Advance time by 1 second (custom interval)
+    vi.advanceTimersByTime(1000);
+    await tick();
+    expect(liveCustomInterval.getAttribute("datetime")).toEqual("PT1H");
+    expect(liveCustomInterval.innerHTML).toEqual("60:00");
+  });
+
+  test("ISO 8601 duration format in datetime attribute", () => {
+    const target = document.body;
+
+    instance = mount(Duration, { target });
+    flushSync();
+
+    // Test various durations and their ISO 8601 representations
+    const oneHour = getElement('[data-test="default"]')!;
+    expect(oneHour.getAttribute("datetime")).toEqual("PT1H");
+
+    const oneMinuteThirty = getElement('[data-test="value-seconds"]')!;
+    expect(oneMinuteThirty.getAttribute("datetime")).toEqual("PT1M30S");
+
+    const twoHours = getElement('[data-test="value-duration-object"]')!;
+    expect(twoHours.getAttribute("datetime")).toEqual("PT2H");
+  });
+});

--- a/tests/SvelteDurationAction.test.svelte
+++ b/tests/SvelteDurationAction.test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { svelteDuration } from "svelte-time";
+</script>
+
+<!-- Basic (default: raw milliseconds) -->
+<time data-test="basic" use:svelteDuration={{ value: 3600000 }}></time>
+<span data-test="basic-span" use:svelteDuration={{ value: 3600000 }}></span>
+
+<!-- With unit -->
+<time data-test="with-unit" use:svelteDuration={{ value: 90, unit: "seconds" }}
+></time>
+
+<!-- With format -->
+<time
+  data-test="with-format"
+  use:svelteDuration={{
+    value: 3600000,
+    format: "HH:mm:ss",
+  }}
+></time>
+
+<!-- With locale -->
+<time
+  data-test="with-locale"
+  use:svelteDuration={{ value: 3600000, humanize: true, locale: "de" }}
+></time>
+
+<!-- Live updates -->
+<time
+  data-test="live"
+  use:svelteDuration={{ value: 3600000, humanize: true, live: true }}
+></time>

--- a/tests/SvelteDurationAction.test.ts
+++ b/tests/SvelteDurationAction.test.ts
@@ -1,0 +1,90 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import SvelteDurationAction from "./SvelteDurationAction.test.svelte";
+
+describe("svelteDuration action", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("works with time element and sets datetime attribute", async () => {
+    const target = document.body;
+    instance = mount(SvelteDurationAction, { target });
+    flushSync();
+
+    const timeElement = getElement('[data-test="basic"]')!;
+    expect(timeElement.tagName).toEqual("TIME");
+    // Default behavior: raw milliseconds
+    expect(timeElement.innerText).toEqual("3600000");
+    expect(timeElement.getAttribute("datetime")).toEqual("PT1H");
+  });
+
+  test("works with span element", async () => {
+    const target = document.body;
+    instance = mount(SvelteDurationAction, { target });
+    flushSync();
+
+    const spanElement = getElement('[data-test="basic-span"]')!;
+    expect(spanElement.tagName).toEqual("SPAN");
+    // Default behavior: raw milliseconds
+    expect(spanElement.innerText).toEqual("3600000");
+  });
+
+  test("formats duration correctly", async () => {
+    const target = document.body;
+    instance = mount(SvelteDurationAction, { target });
+    flushSync();
+
+    const withUnit = getElement('[data-test="with-unit"]')!;
+    // Default behavior: raw milliseconds (90 seconds = 90000 ms)
+    expect(withUnit.innerText).toEqual("90000");
+    expect(withUnit.getAttribute("datetime")).toEqual("PT1M30S");
+
+    const withFormat = getElement('[data-test="with-format"]')!;
+    expect(withFormat.innerText).toEqual("01:00:00");
+    expect(withFormat.getAttribute("datetime")).toEqual("PT1H");
+  });
+
+  test("locale formatting", async () => {
+    // Import locales
+    await import("dayjs/locale/de");
+
+    const target = document.body;
+    instance = mount(SvelteDurationAction, { target });
+    flushSync();
+
+    const withLocale = getElement('[data-test="with-locale"]')!;
+    expect(withLocale.innerText).toEqual("eine Stunde");
+    expect(withLocale.getAttribute("datetime")).toEqual("PT1H");
+  });
+
+  test("live updates", async () => {
+    const target = document.body;
+    instance = mount(SvelteDurationAction, { target });
+    flushSync();
+
+    const live = getElement('[data-test="live"]')!;
+    expect(live.innerText).toEqual("an hour");
+    expect(live.getAttribute("datetime")).toEqual("PT1H");
+
+    // Advance time by 60 seconds (default interval)
+    vi.advanceTimersByTime(60 * 1000);
+    await tick();
+    expect(live.innerText).toEqual("an hour");
+    expect(live.getAttribute("datetime")).toEqual("PT1H");
+  });
+});

--- a/tests/examples/DayjsExport.svelte
+++ b/tests/examples/DayjsExport.svelte
@@ -2,8 +2,13 @@
   import { dayjs } from "svelte-time";
 
   let timestamp = $state("");
+  let duration = $state(null);
 </script>
 
 <button onclick={() => (timestamp = dayjs().format("HH:mm:ss.SSSSSS"))}>
   Update {timestamp}
+</button>
+
+<button onclick={() => (duration = dayjs.duration(2, "hours").humanize())}>
+  Duration: {duration || "Click to see 2 hours"}
 </button>

--- a/tests/examples/DurationBasic.svelte
+++ b/tests/examples/DurationBasic.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Duration, dayjs } from "svelte-time";
+</script>
+
+<div>
+  <!-- Display 1 hour (human-readable) -->
+  <Duration value={3600000} humanize={true} />
+</div>
+
+<div>
+  <!-- Display 90 seconds (human-readable) -->
+  <Duration value={90} unit="seconds" humanize={true} />
+</div>
+
+<div>
+  <!-- Display 2 hours using dayjs Duration object (human-readable) -->
+  <Duration value={dayjs.duration(2, "hours")} humanize={true} />
+</div>

--- a/tests/examples/DurationCustomFormat.svelte
+++ b/tests/examples/DurationCustomFormat.svelte
@@ -1,0 +1,33 @@
+<script>
+  import { Duration } from "svelte-time";
+</script>
+
+<div>
+  <!-- Hours:Minutes:Seconds format -->
+  <Duration value={3661000} format="HH:mm:ss" />
+</div>
+
+<div>
+  <!-- Minutes:Seconds format (total minutes) -->
+  <Duration value={90000} format="mm:ss" />
+</div>
+
+<div>
+  <!-- Hours:Minutes format -->
+  <Duration value={5400000} format="HH:mm" />
+</div>
+
+<div>
+  <!-- Unpadded hours and minutes -->
+  <Duration value={3661000} format="H:m:s" />
+</div>
+
+<div>
+  <!-- Minutes and seconds with milliseconds -->
+  <Duration value={125000} format="mm:ss.SSS" />
+</div>
+
+<div>
+  <!-- Long duration with hours, minutes, seconds -->
+  <Duration value={7323000} format="HH:mm:ss" />
+</div>

--- a/tests/examples/DurationHumanize.svelte
+++ b/tests/examples/DurationHumanize.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Duration, dayjs } from "svelte-time";
+</script>
+
+<div>
+  <!-- Human-readable format -->
+  <Duration value={3600000} humanize={true} />
+</div>
+
+<div>
+  <!-- Custom format (e.g., "01:00:00") -->
+  <Duration value={3600000} format="HH:mm:ss" />
+</div>
+
+<div>
+  <!-- Short format (e.g., "01:30") -->
+  <Duration value={5400000} format="mm:ss" />
+</div>

--- a/tests/examples/DurationLive.svelte
+++ b/tests/examples/DurationLive.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { Duration } from "svelte-time";
+
+  // Countdown timer: 5 minutes (300000 milliseconds)
+  // For a countdown, the value must decrease over time
+  let countdown = $state(5 * 60 * 1000);
+
+  $effect(() => {
+    const interval = setInterval(() => {
+      if (countdown > 0) {
+        countdown -= 1000; // Decrease by 1 second each interval
+      } else {
+        clearInterval(interval);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  });
+</script>
+
+<div>
+  <!-- Countdown timer: value decreases, live prop updates display every second -->
+  <Duration value={countdown} live={1000} format="mm:ss" />
+</div>

--- a/tests/examples/DurationLocale.svelte
+++ b/tests/examples/DurationLocale.svelte
@@ -1,0 +1,15 @@
+<script>
+  import "dayjs/locale/de"; // German locale
+  import "dayjs/locale/es"; // Spanish locale
+  import { Duration } from "svelte-time";
+</script>
+
+<div>
+  <Duration value={3600000} humanize={true} locale="de" />
+  <!-- Output: "eine Stunde" -->
+</div>
+
+<div>
+  <Duration value={120000} humanize={true} locale="es" />
+  <!-- Output: "2 minutos" -->
+</div>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,11 @@
 import * as API from "svelte-time";
 
 test("Library has exports", () => {
-  expect(Object.keys(API).sort()).toEqual(["dayjs", "default", "svelteTime"]);
+  expect(Object.keys(API).sort()).toEqual([
+    "Duration",
+    "dayjs",
+    "default",
+    "svelteDuration",
+    "svelteTime",
+  ]);
 });


### PR DESCRIPTION
Closes #71

One approach for "duration" support is to add new top-level primitives: `Duration` and `use:svelteDuration`.

- Use context module for extending?
- Add raw `dayjs` usage?