### PR TITLE
feat: add `withoutSuffix` prop to remove "ago"

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,47 @@ Specify a custom update interval using the `live` prop.
 ></time>
 ```
 
+### Remove "ago" suffix
+
+Set `withoutSuffix` to `true` to remove the "ago" suffix from relative time.
+
+<!-- render:RelativeTimeWithSuffix -->
+
+```svelte
+<script>
+  import Time, { dayjs } from "svelte-time";
+
+  const pastDate = dayjs().subtract(2, "days").toISOString();
+  const futureDate = dayjs().add(2, "days").toISOString();
+</script>
+
+<!-- Past date -->
+<Time relative timestamp={pastDate} />
+<!-- Output: "2 days ago" -->
+
+<Time relative timestamp={pastDate} withoutSuffix />
+<!-- Output: "2 days" -->
+
+<!-- Future date -->
+<Time relative timestamp={futureDate} />
+<!-- Output: "in 2 days" -->
+
+<Time relative timestamp={futureDate} withoutSuffix />
+<!-- Output: "2 days" -->
+```
+
+This also works with the `svelteTime` action:
+
+```svelte
+<time
+  use:svelteTime={{
+    relative: true,
+    timestamp: "2021-02-02",
+    withoutSuffix: true,
+  }}
+></time>
+```
+
 ### `dayjs` export
 
 The `dayjs` library is exported from this package for your convenience.
@@ -325,6 +366,28 @@ The `locale` prop also works with relative time.
 <Time relative timestamp="2024-01-01" locale="es" />
 <Time relative timestamp="2024-01-01" locale="fr" />
 <Time relative timestamp="2024-01-01" locale="ja" />
+```
+
+The `withoutSuffix` prop also works with locales:
+
+<!-- render:RelativeTimeLocaleWithoutSuffix -->
+
+```svelte
+<script>
+  import "dayjs/locale/de"; // German
+  import "dayjs/locale/es"; // Spanish
+  import "dayjs/locale/fr"; // French
+  import Time from "svelte-time";
+</script>
+
+<Time relative timestamp="2024-01-01" locale="de" withoutSuffix />
+<!-- Output: "2 Jahre" (German, without "vor") -->
+
+<Time relative timestamp="2024-01-01" locale="es" withoutSuffix />
+<!-- Output: "2 años" (Spanish, without "hace") -->
+
+<Time relative timestamp="2024-01-01" locale="fr" withoutSuffix />
+<!-- Output: "2 ans" (French, without "il y a") -->
 ```
 
 ### Reactive locale
@@ -464,14 +527,15 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 
 ### Props
 
-| Name      | Type                                                  | Default value                                                                            |
-| :-------- | :---------------------------------------------------- | :--------------------------------------------------------------------------------------- |
-| timestamp | `string` &#124; `number` &#124; `Date` &#124; `Dayjs` | `new Date().toISOString()`                                                               |
-| format    | `string`                                              | `"MMM DD, YYYY"` (See [dayjs display format](https://day.js.org/docs/en/display/format)) |
-| relative  | `boolean`                                             | `false`                                                                                  |
-| live      | `boolean` &#124; `number`                             | `false`                                                                                  |
-| locale    | `Locales` (TypeScript) &#124; `string`                | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))    |
-| formatted | `string`                                              | `""`                                                                                     |
+| Name          | Type                                                  | Default value                                                                            |
+| :------------ | :---------------------------------------------------- | :--------------------------------------------------------------------------------------- |
+| timestamp     | `string` &#124; `number` &#124; `Date` &#124; `Dayjs` | `new Date().toISOString()`                                                               |
+| format        | `string`                                              | `"MMM DD, YYYY"` (See [dayjs display format](https://day.js.org/docs/en/display/format)) |
+| relative      | `boolean`                                             | `false`                                                                                  |
+| withoutSuffix | `boolean`                                             | `false` (only applies when `relative` is `true`)                                         |
+| live          | `boolean` &#124; `number`                             | `false`                                                                                  |
+| locale        | `Locales` (TypeScript) &#124; `string`                | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))    |
+| formatted     | `string`                                              | `""`                                                                                     |
 
 ## Examples
 

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -22,6 +22,13 @@
     relative = false,
 
     /**
+     * Set to `true` to remove the "ago" suffix from relative time (e.g., "2 hours" instead of "2 hours ago").
+     * Only applies when `relative` is `true`.
+     * @type {boolean}
+     */
+    withoutSuffix = false,
+
+    /**
      * Set to `true` to update the relative time at 60 second interval.
      * Pass in a number (ms) to specify the interval length
      * @type {boolean | number}
@@ -77,14 +84,18 @@
 
   /**
    * Formatted timestamp.
-   * Result of invoking `dayjs().format()`
+   * Result of invoking `dayjs().format()` or `dayjs().from()`
    * @type {string}
    */
   let formatted = $derived.by(() => {
     tick;
-    return relative
-      ? dayjs(timestamp).locale(effectiveLocale).from(dayjs())
-      : dayjs(timestamp).locale(effectiveLocale).format(format);
+    if (relative) {
+      // Use dayjs's built-in withoutSuffix parameter (locale-aware)
+      return dayjs(timestamp)
+        .locale(effectiveLocale)
+        .from(dayjs(), withoutSuffix);
+    }
+    return dayjs(timestamp).locale(effectiveLocale).format(format);
   });
 
   const title = $derived(

--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -28,6 +28,13 @@ export interface TimeProps extends RestProps {
   relative?: boolean;
 
   /**
+   * Set to `true` to remove the "ago" suffix from relative time (e.g., "2 hours" instead of "2 hours ago").
+   * Only applies when `relative` is `true`.
+   * @default false
+   */
+  withoutSuffix?: boolean;
+
+  /**
    * Set to `true` to update the relative time at 60 second interval.
    * Pass in a number (ms) to specify the interval length
    * @default false

--- a/src/svelte-time.svelte.d.ts
+++ b/src/svelte-time.svelte.d.ts
@@ -3,7 +3,13 @@ import type { TimeProps } from "./Time.svelte";
 
 export interface SvelteTimeOptions extends Pick<
   TimeProps,
-  "timestamp" | "format" | "relative" | "live" | "title" | "locale"
+  | "timestamp"
+  | "format"
+  | "relative"
+  | "withoutSuffix"
+  | "live"
+  | "title"
+  | "locale"
 > {}
 
 export const svelteTime: Action<

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -18,6 +18,7 @@ export const svelteTime = (node, options = {}) => {
     const timestamp = options.timestamp || new Date().toISOString();
     const format = options.format || "MMM DD, YYYY";
     const relative = options.relative === true;
+    const withoutSuffix = options.withoutSuffix ?? false;
     const live = options.live ?? false;
     let locale = options.locale ?? "en";
 
@@ -35,22 +36,29 @@ export const svelteTime = (node, options = {}) => {
       }
     }
 
-    let formatted_from = dayjs(timestamp).locale(locale).from(dayjs());
     let formatted = dayjs(timestamp).locale(locale).format(format);
 
     if (relative) {
+      // Use dayjs's built-in withoutSuffix parameter (locale-aware)
+      formatted = dayjs(timestamp).locale(locale).from(dayjs(), withoutSuffix);
+
       if ("title" in options) {
         if (options.title !== undefined) {
           node.setAttribute("title", options.title);
         }
       } else {
-        node.setAttribute("title", formatted);
+        node.setAttribute(
+          "title",
+          dayjs(timestamp).locale(locale).format(format),
+        );
       }
 
       if (live !== false) {
         interval = setInterval(
           () => {
-            node.innerText = dayjs(timestamp).locale(locale).from(dayjs());
+            node.innerText = dayjs(timestamp)
+              .locale(locale)
+              .from(dayjs(), withoutSuffix);
           },
           Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
         );
@@ -60,7 +68,7 @@ export const svelteTime = (node, options = {}) => {
     }
 
     node.setAttribute("datetime", timestamp);
-    node.innerText = relative ? formatted_from : formatted;
+    node.innerText = formatted;
   };
 
   updateTime(options);

--- a/tests/SvelteTimeLocale.test.svelte
+++ b/tests/SvelteTimeLocale.test.svelte
@@ -116,6 +116,59 @@
 
 <time data-test="action-locale-de" use:svelteTime={{ locale: "de" }}></time>
 
+<!-- Relative Time with withoutSuffix in Different Locales -->
+<Time
+  data-test="german-relative-without-suffix"
+  timestamp={fixedDate}
+  relative
+  locale="de"
+  withoutSuffix
+/>
+
+<Time
+  data-test="spanish-relative-without-suffix"
+  timestamp={fixedDate}
+  relative
+  locale="es"
+  withoutSuffix
+/>
+
+<Time
+  data-test="french-relative-without-suffix"
+  timestamp={fixedDate}
+  relative
+  locale="fr"
+  withoutSuffix
+/>
+
+<Time
+  data-test="japanese-relative-without-suffix"
+  timestamp={fixedDate}
+  relative
+  locale="ja"
+  withoutSuffix
+/>
+
+<time
+  data-test="action-locale-de-without-suffix"
+  use:svelteTime={{
+    locale: "de",
+    relative: true,
+    timestamp: fixedDate,
+    withoutSuffix: true,
+  }}
+></time>
+
+<time
+  data-test="action-locale-es-without-suffix"
+  use:svelteTime={{
+    locale: "es",
+    relative: true,
+    timestamp: fixedDate,
+    withoutSuffix: true,
+  }}
+></time>
+
 <!-- Legacy locale behavior: dayjs instance with locale set -->
 <Time
   data-test="legacy-locale-de"

--- a/tests/SvelteTimeLocale.test.ts
+++ b/tests/SvelteTimeLocale.test.ts
@@ -158,6 +158,64 @@ describe("svelte-time-locale", () => {
     );
   });
 
+  test("handles relative time with withoutSuffix in different locales", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeLocale, { target });
+
+    // German relative time without suffix
+    const germanRelativeWithoutSuffix = getElement(
+      '[data-test="german-relative-without-suffix"]',
+    );
+    expect(germanRelativeWithoutSuffix.innerHTML).toEqual(
+      dayjs(FIXED_DATE).locale("de").fromNow(true),
+    );
+
+    // Spanish relative time without suffix
+    const spanishRelativeWithoutSuffix = getElement(
+      '[data-test="spanish-relative-without-suffix"]',
+    );
+    expect(spanishRelativeWithoutSuffix.innerHTML).toEqual(
+      dayjs(FIXED_DATE).locale("es").fromNow(true),
+    );
+
+    // French relative time without suffix
+    const frenchRelativeWithoutSuffix = getElement(
+      '[data-test="french-relative-without-suffix"]',
+    );
+    expect(frenchRelativeWithoutSuffix.innerHTML).toEqual(
+      dayjs(FIXED_DATE).locale("fr").fromNow(true),
+    );
+
+    // Japanese relative time without suffix
+    const japaneseRelativeWithoutSuffix = getElement(
+      '[data-test="japanese-relative-without-suffix"]',
+    );
+    expect(japaneseRelativeWithoutSuffix.innerHTML).toEqual(
+      dayjs(FIXED_DATE).locale("ja").fromNow(true),
+    );
+  });
+
+  test("handles action with locale and withoutSuffix", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeLocale, { target });
+
+    await tick();
+
+    const actionLocaleDeWithoutSuffix = getElement(
+      '[data-test="action-locale-de-without-suffix"]',
+    );
+    expect(actionLocaleDeWithoutSuffix.innerText).toEqual(
+      dayjs(FIXED_DATE).locale("de").fromNow(true),
+    );
+
+    const actionLocaleEsWithoutSuffix = getElement(
+      '[data-test="action-locale-es-without-suffix"]',
+    );
+    expect(actionLocaleEsWithoutSuffix.innerText).toEqual(
+      dayjs(FIXED_DATE).locale("es").fromNow(true),
+    );
+  });
+
   test("preserves locale from dayjs instance (legacy behavior)", async () => {
     const target = document.body;
     instance = mount(SvelteTimeLocale, { target });

--- a/tests/SvelteTimeWithSuffix.test.svelte
+++ b/tests/SvelteTimeWithSuffix.test.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Time from "svelte-time";
+</script>
+
+<!-- Relative with suffix (default) -->
+<Time data-test="relative-with-suffix" relative timestamp="2021-02-02" />
+
+<!-- Relative without suffix -->
+<Time
+  data-test="relative-without-suffix"
+  relative
+  timestamp="2021-02-02"
+  withoutSuffix
+/>
+
+<!-- Future timestamp with suffix (default) -->
+<Time data-test="future-with-suffix" relative timestamp="2025-02-02" />
+
+<!-- Future timestamp without suffix -->
+<Time
+  data-test="future-without-suffix"
+  relative
+  timestamp="2025-02-02"
+  withoutSuffix
+/>

--- a/tests/SvelteTimeWithSuffix.test.ts
+++ b/tests/SvelteTimeWithSuffix.test.ts
@@ -1,0 +1,76 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import SvelteTimeWithSuffixTest from "./SvelteTimeWithSuffix.test.svelte";
+
+describe("Time component with withoutSuffix prop", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("displays relative time with suffix by default", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeWithSuffixTest, { target });
+    flushSync();
+
+    const withSuffix = getElement('[data-test="relative-with-suffix"]');
+    expect(withSuffix).toBeTruthy();
+    const expected = dayjs("2021-02-02").from(dayjs(FIXED_DATE));
+    expect(withSuffix.innerHTML).toEqual(expected);
+    expect(withSuffix.innerHTML).toContain("ago");
+  });
+
+  test("displays relative time without suffix when withoutSuffix is true (past)", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeWithSuffixTest, { target });
+    flushSync();
+
+    const withoutSuffix = getElement('[data-test="relative-without-suffix"]');
+    expect(withoutSuffix).toBeTruthy();
+    // Use dayjs's built-in from() with withoutSuffix parameter
+    const expected = dayjs("2021-02-02").from(dayjs(FIXED_DATE), true);
+    expect(withoutSuffix.innerHTML).toEqual(expected);
+    expect(withoutSuffix.innerHTML).not.toContain("ago");
+  });
+
+  test("displays future time with suffix by default", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeWithSuffixTest, { target });
+    flushSync();
+
+    const withSuffix = getElement('[data-test="future-with-suffix"]');
+    expect(withSuffix).toBeTruthy();
+    const expected = dayjs("2025-02-02").from(dayjs(FIXED_DATE));
+    expect(withSuffix.innerHTML).toEqual(expected);
+    expect(withSuffix.innerHTML).toContain("in");
+  });
+
+  test("displays future time without suffix when withoutSuffix is true (future)", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeWithSuffixTest, { target });
+    flushSync();
+
+    const withoutSuffix = getElement('[data-test="future-without-suffix"]');
+    expect(withoutSuffix).toBeTruthy();
+    // Use dayjs's built-in from() with withoutSuffix parameter
+    const expected = dayjs("2025-02-02").from(dayjs(FIXED_DATE), true);
+    expect(withoutSuffix.innerHTML).toEqual(expected);
+    expect(withoutSuffix.innerHTML).not.toContain("in ");
+  });
+});

--- a/tests/examples/RelativeTimeLocaleWithoutSuffix.svelte
+++ b/tests/examples/RelativeTimeLocaleWithoutSuffix.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import "dayjs/locale/de"; // German
+  import "dayjs/locale/es"; // Spanish
+  import "dayjs/locale/fr"; // French
+  import Time from "svelte-time";
+</script>
+
+<div>
+  <Time relative timestamp="2024-01-01" locale="de" withoutSuffix />
+</div>
+
+<div>
+  <Time relative timestamp="2024-01-01" locale="es" withoutSuffix />
+</div>
+
+<div>
+  <Time relative timestamp="2024-01-01" locale="fr" withoutSuffix />
+</div>

--- a/tests/examples/RelativeTimeWithSuffix.svelte
+++ b/tests/examples/RelativeTimeWithSuffix.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Time, { dayjs } from "svelte-time";
+
+  const pastDate = dayjs().subtract(2, "days").toISOString();
+  const futureDate = dayjs().add(2, "days").toISOString();
+</script>
+
+<div>
+  <Time relative timestamp={pastDate} />
+</div>
+
+<div>
+  <Time relative timestamp={pastDate} withoutSuffix />
+</div>
+
+<div>
+  <Time relative timestamp={futureDate} />
+</div>
+
+<div>
+  <Time relative timestamp={futureDate} withoutSuffix />
+</div>


### PR DESCRIPTION
Closes #49 

Adds a `withoutSuffix` prop to the `Time` component and `svelteTime` action that removes the "ago" suffix (or "in" prefix) from relative time displays. The implementation uses dayjs's built-in locale-aware `from()` method, ensuring it works correctly with all supported locales.

## Usage

### Component

```svelte
<script>
  import Time, { dayjs } from "svelte-time";

  const pastDate = dayjs().subtract(2, "days").toISOString();
  const futureDate = dayjs().add(2, "days").toISOString();
</script>

<!-- Past date -->
<Time relative timestamp={pastDate} />
<!-- Output: "2 days ago" -->

<Time relative timestamp={pastDate} withoutSuffix />
<!-- Output: "2 days" -->

<!-- Future date -->
<Time relative timestamp={futureDate} />
<!-- Output: "in 2 days" -->

<Time relative timestamp={futureDate} withoutSuffix />
<!-- Output: "2 days" -->
```
### `svelteTime` action

```svelte
<time
  use:svelteTime={{
    relative: true,
    timestamp: "2021-02-02",
    withoutSuffix: true,
  }}
></time>
```

### Locale-aware

Works correctly with all dayjs locales:

```svelte
<script>
  import "dayjs/locale/de"; // German
  import "dayjs/locale/es"; // Spanish
  import "dayjs/locale/fr"; // French
  import Time from "svelte-time";
</script>

<Time relative timestamp="2024-01-01" locale="de" withoutSuffix />
<!-- Output: "2 Jahre" (without "vor") -->

<Time relative timestamp="2024-01-01" locale="es" withoutSuffix />
<!-- Output: "2 años" (without "hace") -->

<Time relative timestamp="2024-01-01" locale="fr" withoutSuffix />
<!-- Output: "2 ans" (without "il y a") -->
```

