### PR TITLE
test: add SSR test lane and CI timezone matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tz: [UTC, America/Los_Angeles, Pacific/Auckland]
+    env:
+      TZ: ${{ matrix.tz }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/tests/ssr/Time.ssr.test.ts
+++ b/tests/ssr/Time.ssr.test.ts
@@ -1,0 +1,34 @@
+import { render } from "svelte/server";
+import Time, { dayjs } from "svelte-time";
+
+describe("Time (SSR)", () => {
+  const TS = "2024-01-01T00:00:00.000Z";
+
+  test("renders a populated <time> element on the server", () => {
+    const { body } = render(Time, { props: { timestamp: TS } });
+    expect(body).toContain("<time");
+    expect(body).toContain(dayjs(TS).format("MMM DD, YYYY"));
+    expect(body).toContain(`datetime="${TS}"`);
+  });
+
+  test("relative mode renders text and a title on the server", () => {
+    const { body } = render(Time, { props: { timestamp: TS, relative: true } });
+    expect(body).toContain(dayjs(TS).from(dayjs()));
+    expect(body).toContain(`title="${dayjs(TS).format("MMM DD, YYYY")}"`);
+  });
+
+  test("live mode starts no timers on the server", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    render(Time, { props: { timestamp: TS, relative: true, live: true } });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("never renders 'Invalid Date' for valid inputs", () => {
+    for (const timestamp of [TS, 0, new Date(TS), dayjs(TS)]) {
+      expect(render(Time, { props: { timestamp } }).body).not.toContain(
+        "Invalid Date",
+      );
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,28 @@ export default defineConfig({
   ],
   resolve: {
     alias: { [pkg.name]: path.resolve("./src") },
-    conditions: ["browser"],
   },
-  test: { globals: true, environment: "jsdom" },
+  test: {
+    globals: true,
+    projects: [
+      {
+        extends: true,
+        resolve: { conditions: ["browser"] },
+        test: {
+          name: "client",
+          environment: "jsdom",
+          include: ["**/*.test.ts"],
+          exclude: ["**/node_modules/**", "ssr/**"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "ssr",
+          environment: "node",
+          include: ["ssr/**/*.test.ts"],
+        },
+      },
+    ],
+  },
 });


### PR DESCRIPTION
Split Vitest into two projects: the existing jsdom suite (browser condition now scoped to that project) and a new node-environment lane that renders components with svelte/server. Adds an SSR contract test covering server-rendered output, relative titles, and the guarantee that live mode starts no timers during SSR.

CI now runs the suite under UTC, America/Los_Angeles, and Pacific/Auckland to surface date-boundary bugs that only reproduce in specific timezones.

No source changes; test infrastructure only.