### PR TITLE
fix: svelteTime action no longer drops falsy timestamps

### DIFF
--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -15,7 +15,7 @@ export const svelteTime = (node, options = {}) => {
     clearInterval(interval);
     interval = undefined;
 
-    const timestamp = options.timestamp || new Date().toISOString();
+    const timestamp = options.timestamp ?? new Date().toISOString();
     const format = options.format || "MMM DD, YYYY";
     const relative = options.relative === true;
     const withoutSuffix = options.withoutSuffix ?? false;

--- a/tests/SvelteTimeParity.test.ts
+++ b/tests/SvelteTimeParity.test.ts
@@ -1,0 +1,45 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import Time, { svelteTime } from "svelte-time";
+
+describe("component/action parity for edge-case timestamps", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  const FORMAT = "YYYY-MM-DD";
+  const CASES: Array<[name: string, timestamp: unknown, expected: string]> = [
+    ["epoch (0)", 0, dayjs(0).format(FORMAT)],
+    ["empty string", "", "Invalid Date"],
+    ["date string", "2020-02-01", dayjs("2020-02-01").format(FORMAT)],
+  ];
+
+  for (const [name, timestamp, expected] of CASES) {
+    test(`${name}: component and action agree`, () => {
+      const instance = mount(Time, {
+        target: document.body,
+        props: { "data-test": "component", timestamp, format: FORMAT },
+      });
+      flushSync();
+
+      const node = document.createElement("time");
+      document.body.appendChild(node);
+      const action = svelteTime(node, { timestamp, format: FORMAT });
+
+      const componentText = document
+        .querySelector('[data-test="component"]')
+        ?.textContent?.trim();
+      expect(componentText).toEqual(expected);
+      expect(node.innerText?.trim()).toEqual(expected);
+
+      action?.destroy?.();
+      unmount(instance);
+    });
+  }
+});


### PR DESCRIPTION
fix: `svelteTime` action no longer drops falsy timestamps

The action defaulted its timestamp with `options.timestamp || ...`,
which treats the Unix epoch (0) and empty strings as absent and
silently rendered the current date instead. The Time component already
handled these inputs correctly, so the component and action disagreed.

Switch to nullish coalescing so only null/undefined fall back to "now".

Behavior note: `timestamp: ""` now renders "Invalid Date" through the
action, matching the component, instead of falling back to the current
date.

Adds a component/action parity test matrix for edge-case timestamps.
