### PR TITLE
fix: emit valid ISO 8601 datetime for non-string timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The displayed time defaults to `new Date().toISOString()` and is formatted as `"
 <Time />
 ```
 
-The `timestamp` prop can be any of the following `dayjs` values: `string | number | Date | Dayjs`.
+The `timestamp` prop can be any of the following `dayjs` values: `string | number | Date | Dayjs`. String timestamps are written to `datetime` as-is; `Date`/`Dayjs`/`number` inputs are normalized to ISO 8601; invalid inputs omit the attribute.
 
 <!-- render:CustomTimestamp -->
 

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -44,6 +44,7 @@
   } = $props();
 
   import { dayjs } from "./dayjs";
+  import { toDatetime } from "./datetime";
 
   const DEFAULT_INTERVAL = 60 * 1_000;
 
@@ -105,6 +106,6 @@
   );
 </script>
 
-<time {title} {...rest} datetime={timestamp}>
+<time {title} {...rest} datetime={toDatetime(timestamp)}>
   {formatted}
 </time>

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -1,0 +1,16 @@
+import { dayjs } from "./dayjs";
+
+/**
+ * Machine-readable value for the `datetime` attribute.
+ * Valid strings pass through untouched (the user may already provide a
+ * spec-valid value dayjs can't parse-and-reproduce); Date/Dayjs/number
+ * inputs are normalized to ISO 8601. Invalid inputs return undefined so
+ * the attribute is omitted rather than set to garbage.
+ * @param {import("dayjs").ConfigType} timestamp
+ * @returns {string | undefined}
+ */
+export function toDatetime(timestamp) {
+  const day = dayjs(timestamp);
+  if (!day.isValid()) return undefined;
+  return typeof timestamp === "string" ? timestamp : day.toISOString();
+}

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -1,4 +1,5 @@
 import { dayjs } from "./dayjs";
+import { toDatetime } from "./datetime";
 
 /**
  * @typedef {import("./svelte-time.svelte").SvelteTimeOptions} SvelteTimeOptions
@@ -67,7 +68,12 @@ export const svelteTime = (node, options = {}) => {
       node.removeAttribute("title");
     }
 
-    node.setAttribute("datetime", timestamp);
+    const datetime = toDatetime(timestamp);
+    if (datetime === undefined) {
+      node.removeAttribute("datetime");
+    } else {
+      node.setAttribute("datetime", datetime);
+    }
     node.innerText = formatted;
   };
 

--- a/tests/DatetimeAttribute.test.ts
+++ b/tests/DatetimeAttribute.test.ts
@@ -1,0 +1,93 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import Time, { svelteTime } from "svelte-time";
+
+describe("datetime attribute contract", () => {
+  const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+  let instance: null | ReturnType<typeof mount> = null;
+
+  afterEach(() => {
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  function renderComponent(timestamp: unknown) {
+    instance = mount(Time, {
+      target: document.body,
+      props: {
+        timestamp,
+        format: "YYYY-MM-DD",
+        "data-test": "component",
+      },
+    });
+    flushSync();
+    return document.querySelector('[data-test="component"]') as HTMLElement;
+  }
+
+  function renderAction(timestamp: unknown) {
+    const node = document.createElement("time");
+    node.setAttribute("data-test", "action");
+    document.body.appendChild(node);
+    svelteTime(node, {
+      timestamp,
+      format: "YYYY-MM-DD",
+    });
+    return node;
+  }
+
+  test.each([
+    ["Date", new Date("2024-01-01T00:00:00.000Z")],
+    ["Dayjs", dayjs("2024-01-01T00:00:00.000Z")],
+    ["number", 1e10],
+  ])(
+    "%s inputs are normalized to ISO 8601 in both render paths",
+    (_, timestamp) => {
+      const component = renderComponent(timestamp);
+      expect(component.getAttribute("datetime")).toMatch(ISO);
+
+      if (instance) {
+        unmount(instance);
+        instance = null;
+      }
+      document.body.innerHTML = "";
+
+      const action = renderAction(timestamp);
+      expect(action.getAttribute("datetime")).toMatch(ISO);
+    },
+  );
+
+  test("string inputs pass through as-is in both render paths", () => {
+    const timestamp = "2020-02-01";
+
+    const component = renderComponent(timestamp);
+    expect(component.getAttribute("datetime")).toEqual(timestamp);
+
+    if (instance) {
+      unmount(instance);
+      instance = null;
+    }
+    document.body.innerHTML = "";
+
+    const action = renderAction(timestamp);
+    expect(action.getAttribute("datetime")).toEqual(timestamp);
+  });
+
+  test("invalid inputs omit the datetime attribute in both render paths", () => {
+    const timestamp = "not a date";
+
+    const component = renderComponent(timestamp);
+    expect(component.hasAttribute("datetime")).toEqual(false);
+
+    if (instance) {
+      unmount(instance);
+      instance = null;
+    }
+    document.body.innerHTML = "";
+
+    const action = renderAction(timestamp);
+    expect(action.hasAttribute("datetime")).toEqual(false);
+  });
+});

--- a/tests/SvelteTime.test.ts
+++ b/tests/SvelteTime.test.ts
@@ -52,13 +52,15 @@ describe("svelte-time", () => {
     expect(timestampDate.innerHTML).toEqual(
       dayjs(date).format("dddd @ h:mm a"),
     );
-    expect(timestampDate.getAttribute("datetime")).toEqual(date + "");
+    expect(timestampDate.getAttribute("datetime")).toEqual(date.toISOString());
 
     const timestampNumber = getElement('[data-test="timestamp-number"]')!;
     expect(timestampNumber.innerHTML).toEqual(
       dayjs(1e10).format("dddd @ h:mm A · MMMM D, YYYY"),
     );
-    expect(timestampNumber.getAttribute("datetime")).toEqual(1e10 + "");
+    expect(timestampNumber.getAttribute("datetime")).toEqual(
+      new Date(1e10).toISOString(),
+    );
 
     const relative = getElement('[data-test="relative"]')!;
     expect(relative.innerHTML).toEqual("a few seconds ago");
@@ -72,7 +74,9 @@ describe("svelte-time", () => {
       '[data-test="relative-timestamp-number"]',
     )!;
     expect(relativeTimestampNumber.innerHTML).toEqual("54 years ago");
-    expect(relativeTimestampNumber.getAttribute("datetime")).toEqual(1e10 + "");
+    expect(relativeTimestampNumber.getAttribute("datetime")).toEqual(
+      new Date(1e10).toISOString(),
+    );
 
     const relativeLive = getElement('[data-test="relative-live"]');
     const actionRelativeLive = getElement('[data-test="action-relative-live"]');

--- a/tests/SvelteTimeEdgeCases.test.ts
+++ b/tests/SvelteTimeEdgeCases.test.ts
@@ -236,7 +236,9 @@ describe("svelte-time-edge-cases", () => {
       const element = getElement('[data-test="epoch"]');
       const formattedDate = dayjs(0).format("YYYY-MM-DD");
       expect(element.innerHTML).toEqual(formattedDate);
-      expect(element.getAttribute("datetime")).toEqual("0");
+      expect(element.getAttribute("datetime")).toEqual(
+        "1970-01-01T00:00:00.000Z",
+      );
     });
 
     test("undefined timestamp should use default (current date)", async () => {

--- a/tests/ssr/Time.ssr.test.ts
+++ b/tests/ssr/Time.ssr.test.ts
@@ -11,6 +11,12 @@ describe("Time (SSR)", () => {
     expect(body).toContain(`datetime="${TS}"`);
   });
 
+  test("normalizes Date inputs to ISO in the server-rendered datetime attribute", () => {
+    const date = new Date(TS);
+    const { body } = render(Time, { props: { timestamp: date } });
+    expect(body).toContain(`datetime="${date.toISOString()}"`);
+  });
+
   test("relative mode renders text and a title on the server", () => {
     const { body } = render(Time, { props: { timestamp: TS, relative: true } });
     expect(body).toContain(dayjs(TS).from(dayjs()));


### PR DESCRIPTION
Date, Dayjs, and number timestamps were string-coerced into the
datetime attribute, producing values like
"Tue Jul 07 2026 09:38:57 GMT-0700 (Pacific Daylight Time)" — not valid
per the HTML <time> spec, which defeats the library's purpose of
encoding a machine-parseable value.

Both the component and the action now normalize non-string inputs to
ISO 8601 via a shared toDatetime() helper. String inputs pass through
untouched. Invalid timestamps omit the attribute entirely instead of
rendering garbage (calling toISOString() on an invalid date would
throw).

Behavior note: consumers snapshotting rendered HTML will see datetime
values change from Date/Dayjs toString() output to ISO 8601.

Adds a datetime contract test (ISO regex across all input types,
component and action) and tightens the SSR contract accordingly.