### PR TITLE
perf: write action output via textContent

### DIFF
--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -57,7 +57,7 @@ export const svelteTime = (node, options = {}) => {
       if (live !== false) {
         interval = setInterval(
           () => {
-            node.innerText = dayjs(timestamp)
+            node.textContent = dayjs(timestamp)
               .locale(locale)
               .from(dayjs(), withoutSuffix);
           },
@@ -74,7 +74,7 @@ export const svelteTime = (node, options = {}) => {
     } else {
       node.setAttribute("datetime", datetime);
     }
-    node.innerText = formatted;
+    node.textContent = formatted;
   };
 
   updateTime(options);

--- a/tests/SvelteTimeAction.test.ts
+++ b/tests/SvelteTimeAction.test.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import { flushSync, mount, unmount } from "svelte";
+import { svelteTime } from "../src/svelte-time.svelte.js";
 import SvelteTimeAction from "./examples/SvelteTimeAction.svelte";
 
 describe("svelte-time-action", () => {
@@ -80,6 +81,19 @@ describe("svelte-time-action", () => {
     expect(timeElement.tagName.toLowerCase()).toBe("time");
     // The action should preserve the original element structure
     expect(timeElement.children.length).toBe(0);
+  });
+
+  test("writes plain text content (single text node)", () => {
+    const node = document.createElement("time");
+    document.body.appendChild(node);
+    const handle = svelteTime(node, {
+      timestamp: "2020-02-01",
+      format: "YYYY-MM-DD",
+    });
+    expect(node.childNodes.length).toBe(1);
+    expect(node.childNodes[0].nodeType).toBe(Node.TEXT_NODE);
+    expect(node.textContent).toBe("2020-02-01");
+    handle?.destroy?.();
   });
 
   // Regression test for https://github.com/metonym/svelte-time/issues/66

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,15 @@
+if (
+  typeof window !== "undefined" &&
+  !("innerText" in HTMLElement.prototype)
+) {
+  Object.defineProperty(HTMLElement.prototype, "innerText", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      return this.textContent ?? "";
+    },
+    set(value) {
+      this.textContent = value;
+    },
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
         test: {
           name: "client",
           environment: "jsdom",
+          setupFiles: ["./setup.ts"],
           include: ["**/*.test.ts"],
           exclude: ["**/node_modules/**", "ssr/**"],
         },


### PR DESCRIPTION
The svelteTime action wrote its output with innerText, a layout-aware
API, including inside the live setInterval callback — the hottest path
in the library. textContent performs the identical child-replacement
without layout entanglement, so pages with many live elements avoid
layout-invalidating writes on every tick.

No behavior change; innerText reads in tests reflect textContent
writes. Adds a regression test pinning plain-text (single text node)
output.