### PR TITLE
perf: share one live-update timer across components

### DIFF
--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -45,22 +45,17 @@
 
   import { dayjs } from "./dayjs";
   import { toDatetime } from "./datetime";
+  import { sharedNow } from "./ticker";
 
   const DEFAULT_INTERVAL = 60 * 1_000;
 
-  let now = $state(dayjs());
+  const canTick = typeof document !== "undefined";
 
-  $effect(() => {
-    if (relative && live !== false) {
-      const interval = setInterval(
-        () => {
-          now = dayjs();
-        },
-        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
-      );
-      return () => clearInterval(interval);
-    }
-  });
+  const now = $derived(
+    relative && live !== false && canTick
+      ? sharedNow(Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL))
+      : dayjs(),
+  );
 
   /**
    * Get the effective locale to use.

--- a/src/ticker.js
+++ b/src/ticker.js
@@ -1,0 +1,36 @@
+import { createSubscriber } from "svelte/reactivity";
+import { dayjs } from "./dayjs";
+
+/**
+ * One shared timer per distinct interval (ms), active only while
+ * subscribed. The map is bounded by the number of distinct interval
+ * values in the app.
+ */
+const tickers = new Map();
+
+/**
+ * Reactive "now". When read inside an effect or derived, the caller
+ * re-runs on every tick of the shared timer for `intervalMs`.
+ * @param {number} intervalMs
+ * @returns {import("dayjs").Dayjs}
+ */
+export function sharedNow(intervalMs) {
+  let read = tickers.get(intervalMs);
+  if (!read) {
+    let now = dayjs();
+    const subscribe = createSubscriber((update) => {
+      now = dayjs(); // refresh on (re)activation — the module may be old
+      const id = setInterval(() => {
+        now = dayjs();
+        update();
+      }, intervalMs);
+      return () => clearInterval(id);
+    });
+    read = () => {
+      subscribe();
+      return now;
+    };
+    tickers.set(intervalMs, read);
+  }
+  return read();
+}

--- a/tests/SvelteTimeEdgeCases.test.ts
+++ b/tests/SvelteTimeEdgeCases.test.ts
@@ -110,9 +110,27 @@ describe("svelte-time-edge-cases", () => {
 
       unmount(instance);
       instance = null;
+      await tick(); // createSubscriber defers teardown by a microtask
 
       expect(clearIntervalSpy).toHaveBeenCalled();
       clearIntervalSpy.mockRestore();
+    });
+
+    test("live components with the same interval share one timer", () => {
+      const spy = vi.spyOn(global, "setInterval");
+      const a = mount(Time, {
+        target: document.body,
+        props: { relative: true, live: true },
+      });
+      const b = mount(Time, {
+        target: document.body,
+        props: { relative: true, live: true },
+      });
+      flushSync();
+      expect(spy).toHaveBeenCalledTimes(1); // was 2 before this change
+      unmount(a);
+      unmount(b);
+      spy.mockRestore();
     });
 
     test("multiple components should each manage their own intervals", async () => {
@@ -176,6 +194,7 @@ describe("svelte-time-edge-cases", () => {
         flushSync();
         unmount(inst);
         document.body.innerHTML = "";
+        await tick(); // createSubscriber defers teardown by a microtask
       }
 
       expect(clearIntervalSpy).toHaveBeenCalledTimes(100);


### PR DESCRIPTION
Closes #29

- A feed rendering 1,000 `<Time relative live />` instances used to schedule 1,000 independent `setInterval` timers. Live components now read a shared reactive clock via `sharedNow()` (`src/ticker.js`), built on `createSubscriber` from `svelte/reactivity` — one timer per distinct interval value, started on first subscriber, torn down on last unsubscribe.
- `n` components at one interval value collapse from `n` timer wakeups/tick to `1` (1,000 components at 60s: 1,000 wakeups/min → 1).
- SSR path is unaffected: `now` is guarded by `typeof document !== "undefined"` and always computed fresh per render, so the server never starts a timer (also true independently, since `createSubscriber`'s server stub is a no-op).

