### PR TITLE
chore: remove dead dayjs.ts from package

### DIFF
--- a/src/datetime.d.ts
+++ b/src/datetime.d.ts
@@ -1,0 +1,10 @@
+import type { ConfigType } from "dayjs";
+
+/**
+ * Machine-readable value for the `datetime` attribute.
+ * Valid strings pass through untouched (the user may already provide a
+ * spec-valid value dayjs can't parse-and-reproduce); Date/Dayjs/number
+ * inputs are normalized to ISO 8601. Invalid inputs return undefined so
+ * the attribute is omitted rather than set to garbage.
+ */
+export declare function toDatetime(timestamp: ConfigType): string | undefined;

--- a/src/dayjs.d.ts
+++ b/src/dayjs.d.ts
@@ -1,0 +1,4 @@
+import dayjs from "dayjs";
+import "dayjs/plugin/relativeTime.js";
+
+export { dayjs };

--- a/src/dayjs.ts
+++ b/src/dayjs.ts
@@ -1,6 +1,0 @@
-import dayjs from "dayjs/esm";
-import relativeTime from "dayjs/esm/plugin/relativeTime";
-
-dayjs.extend(relativeTime);
-
-export { dayjs };

--- a/src/ticker.d.ts
+++ b/src/ticker.d.ts
@@ -1,0 +1,7 @@
+import type { Dayjs } from "dayjs";
+
+/**
+ * Reactive "now". When read inside an effect or derived, the caller
+ * re-runs on every tick of the shared timer for `intervalMs`.
+ */
+export declare function sharedNow(intervalMs: number): Dayjs;


### PR DESCRIPTION
## Summary
- `src/dayjs.ts` (importing `dayjs/esm`) was dead code — module resolution picks `dayjs.js` (the CJS entry) everywhere in this repo — but `npm pack` confirms it shipped in the published `svelte-time@2.1.0` tarball. Any consumer toolchain that resolves `.ts` before `.js` would silently get the esm dayjs instance, on which user-registered locales (`import "dayjs/locale/xx"`, which register against the CJS instance) don't exist. Deleted so exactly one dayjs instance is possible.
- Follow-up: while verifying the packaging output, found that `dlz`'s exports-map generator naively assumes every `.js` has a sibling `.d.ts` (string-replace, no existence check) — and `src/dayjs.js`, `src/datetime.js`, `src/ticker.js` never had one. This predates this PR (confirmed against `npm pack svelte-time@2.1.0`, and by running `bun run package` on the prior commit — all three `.d.ts` were already missing there too). Added the three missing hand-rolled `.d.ts` files so `svelte-time/dayjs`, `svelte-time/datetime`, and `svelte-time/ticker` resolve types correctly.

