### PR TITLE
fix: correct format type, drop phantom formatted prop, export public types

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,11 @@ To use a [custom locale](https://day.js.org/docs/en/i18n/changing-locale), impor
 <Time timestamp="2024-01-01" format="YYYY年M月D日(dddd)" locale="ja" />
 ```
 
-The `Locales` type is exported for TypeScript usage.
+The `Locales` type is exported for TypeScript usage, along with `TimeProps` and
+`SvelteTimeOptions` for typing component wrappers and action options.
 
 ```typescript
-import type { Locales } from "svelte-time";
+import type { Locales, TimeProps, SvelteTimeOptions } from "svelte-time";
 
 const locale: Locales = "de";
 const localeStore = writable<Locales>("en");
@@ -535,7 +536,6 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 | withoutSuffix | `boolean`                                             | `false` (only applies when `relative` is `true`)                                         |
 | live          | `boolean` &#124; `number`                             | `false`                                                                                  |
 | locale        | `Locales` (TypeScript) &#124; `string`                | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))    |
-| formatted     | `string`                                              | `""`                                                                                     |
 
 ## Examples
 

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -9,7 +9,7 @@
     /**
      * Timestamp format for display.
      * It's also used as a title in the `relative` mode
-     * @type {import("dayjs").OptionType}
+     * @type {string}
      * @example "YYYY-MM-DD"
      */
     format = "MMM DD, YYYY",

--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -1,4 +1,4 @@
-import type { ConfigType, OptionType } from "dayjs";
+import type { ConfigType } from "dayjs";
 import type { Component } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 import type { Locales } from "./locales";
@@ -15,10 +15,9 @@ export interface TimeProps extends RestProps {
   /**
    * Timestamp format for display.
    * It's also used as a title in the `relative` mode
-   * @type {import("dayjs").OptionType}
    * @default "MMM DD, YYYY"
    */
-  format?: OptionType;
+  format?: string;
 
   /**
    * Set to `true` to display the relative time from the provided `timestamp`.
@@ -46,13 +45,6 @@ export interface TimeProps extends RestProps {
    * @default "en"
    */
   locale?: Locales;
-
-  /**
-   * Formatted timestamp.
-   * Result of invoking `dayjs().format()`
-   * @default ""
-   */
-  formatted?: string;
 
   [key: `data-${string}`]: any;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,3 +2,5 @@ export { dayjs } from "./dayjs";
 export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";
 export type { Locales } from "./locales";
+export type { TimeProps } from "./Time.svelte";
+export type { SvelteTimeOptions } from "./svelte-time.svelte";

--- a/tests/types.test-d.ts
+++ b/tests/types.test-d.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf, test } from "vitest";
+import type { TimeProps, SvelteTimeOptions, Locales } from "svelte-time";
+
+test("format is a plain string", () => {
+  expectTypeOf<TimeProps["format"]>().toEqualTypeOf<string | undefined>();
+});
+
+test("formatted is not a prop", () => {
+  // @ts-expect-error — formatted was removed; it is not a component prop
+  const props: TimeProps = { formatted: "" };
+  void props;
+});
+
+test("action options are exported and include title", () => {
+  expectTypeOf<SvelteTimeOptions["title"]>().not.toBeNever();
+  expectTypeOf<Locales>().toExtend<string>();
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,11 @@ export default defineConfig({
           setupFiles: ["./setup.ts"],
           include: ["**/*.test.ts"],
           exclude: ["**/node_modules/**", "ssr/**"],
+          typecheck: {
+            enabled: true,
+            include: ["**/*.test-d.ts"],
+            ignoreSourceErrors: true,
+          },
         },
       },
       {


### PR DESCRIPTION
## Summary
- `format` was typed as dayjs's `OptionType` (a *parsing* type); it is actually a plain display-format string passed to `.format()`. Types now match the documented API and the README's props table (which already said `string`).
- `formatted` was declared in `Time.svelte.d.ts` and documented in the README props table, but the Svelte 5 rewrite of `Time.svelte` never implemented it — it was a leftover v1 `bind:`-able export. Removed from types and docs.
- `TimeProps` and `SvelteTimeOptions` are now exported from the package root so consumers can type component wrappers and action options without reaching into internals.

## Not a breaking change
Nothing changes at runtime — `formatted` never worked on the Svelte 5 component, and `.format()` always required a string, so behavior is identical before and after. Only TypeScript consumers who explicitly referenced the now-removed/narrowed types would see new compile errors, and those usages were already incorrect (they described capabilities the runtime component never had).

## Tests
Added `tests/types.test-d.ts` — a Vitest typecheck suite (`typecheck.enabled` on the `client` project, scoped to `**/*.test-d.ts` with `ignoreSourceErrors: true` since the repo's broader `tsconfig.json` program has pre-existing unrelated type errors outside this change's scope) that fails CI if types drift from the runtime component again. Verified the `@ts-expect-error` guard is real by temporarily removing it and confirming the test fails.
