### PR TITLE
feat: support children snippet for custom markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Set the value to `undefined` to omit the `title` altogether.
 <Time relative title={undefined} />
 ```
 
+### Custom markup
+
+Pass a `children` snippet to render custom markup instead of the plain formatted text. The snippet receives the formatted value as its argument, and the component still owns the `<time>` element, `title`, and `datetime` handling.
+
+<!-- render:CustomMarkup -->
+
+```svelte
+<Time relative timestamp={post.createdAt}>
+  {#snippet children(formatted)}
+    <strong>{formatted}</strong>
+  {/snippet}
+</Time>
+```
+
 ### Live updates
 
 Set `live` to `true` for a live updating relative timestamp. Updates follow an adaptive schedule based on the timestamp's age — every 10s while under a minute old, 30s while under an hour old, 5 minutes while under a day old, and hourly beyond that — migrating to the slower tier as the timestamp ages. It also refreshes immediately when a backgrounded tab becomes visible again, so you never see stale, timer-throttled text.
@@ -536,6 +550,7 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 | withoutSuffix | `boolean`                                             | `false` (only applies when `relative` is `true`)                                         |
 | live          | `boolean` &#124; `number`                             | `false`                                                                                  |
 | locale        | `Locales` (TypeScript) &#124; `string`                | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))    |
+| children      | `Snippet<[string]>`                                   | `undefined`                                                                              |
 
 ## Examples
 

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -40,6 +40,13 @@
      * @type {import("./locales").Locales}
      */
     locale = "en",
+
+    /**
+     * Snippet rendered inside the `time` element instead of the plain
+     * formatted string. Receives the formatted value as its argument.
+     * @type {import("svelte").Snippet<[string]> | undefined}
+     */
+    children,
     ...rest
   } = $props();
 
@@ -127,6 +134,12 @@
   const title = $derived(relative ? day.format(format) : undefined);
 </script>
 
-<time {title} {...rest} datetime={toDatetime(timestamp)}>
-  {formatted}
-</time>
+{#if children}
+  <time {title} {...rest} datetime={toDatetime(timestamp)}>
+    {@render children(formatted)}
+  </time>
+{:else}
+  <time {title} {...rest} datetime={toDatetime(timestamp)}>
+    {formatted}
+  </time>
+{/if}

--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -1,9 +1,9 @@
 import type { ConfigType } from "dayjs";
-import type { Component } from "svelte";
+import type { Component, Snippet } from "svelte";
 import type { SvelteHTMLElements } from "svelte/elements";
 import type { Locales } from "./locales";
 
-type RestProps = SvelteHTMLElements["time"];
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
 
 export interface TimeProps extends RestProps {
   /**
@@ -45,6 +45,12 @@ export interface TimeProps extends RestProps {
    * @default "en"
    */
   locale?: Locales;
+
+  /**
+   * Snippet rendered inside the `time` element instead of the plain
+   * formatted string. Receives the formatted value as its argument.
+   */
+  children?: Snippet<[string]>;
 
   [key: `data-${string}`]: any;
 }

--- a/tests/SvelteTimeChildren.test.svelte
+++ b/tests/SvelteTimeChildren.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Time from "svelte-time";
+</script>
+
+<Time data-test="children-markup" timestamp="2024-01-01T00:00:00.000Z">
+  {#snippet children(formatted)}
+    <strong>{formatted}</strong>
+  {/snippet}
+</Time>
+
+<Time data-test="children-live" relative live>
+  {#snippet children(formatted)}
+    <em>{formatted}</em>
+  {/snippet}
+</Time>
+
+<Time data-test="no-children" timestamp="2024-01-01T00:00:00.000Z" />

--- a/tests/SvelteTimeChildren.test.ts
+++ b/tests/SvelteTimeChildren.test.ts
@@ -1,0 +1,71 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import SvelteTimeChildren from "./SvelteTimeChildren.test.svelte";
+
+describe("svelte-time-children", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("renders custom markup inside <time> without changing datetime/title", () => {
+    const target = document.body;
+    instance = mount(SvelteTimeChildren, { target });
+    flushSync();
+
+    const el = getElement('[data-test="children-markup"]');
+    const strong = el.querySelector("strong");
+
+    expect(strong).not.toBeNull();
+    expect(strong!.textContent).toEqual(
+      dayjs("2024-01-01T00:00:00.000Z").format("MMM DD, YYYY"),
+    );
+    expect(el.getAttribute("datetime")).toEqual("2024-01-01T00:00:00.000Z");
+    expect(el.hasAttribute("title")).toEqual(false);
+  });
+
+  test("snippet stays live", () => {
+    const target = document.body;
+    instance = mount(SvelteTimeChildren, { target });
+    flushSync();
+
+    const el = getElement('[data-test="children-live"]');
+    const text = () => el.querySelector("em")!.textContent;
+
+    expect(text()).toEqual(dayjs(FIXED_DATE).from(dayjs(FIXED_DATE)));
+
+    vi.runOnlyPendingTimers();
+    flushSync();
+
+    expect(text()).toEqual(dayjs(FIXED_DATE).from(dayjs()));
+  });
+
+  test("without a snippet, renders the plain formatted text as before", () => {
+    const target = document.body;
+    instance = mount(SvelteTimeChildren, { target });
+    flushSync();
+
+    const el = getElement('[data-test="no-children"]');
+
+    expect(el.querySelector("strong, em")).toBeNull();
+    expect(el.innerHTML.trim()).toEqual(
+      dayjs("2024-01-01T00:00:00.000Z").format("MMM DD, YYYY"),
+    );
+  });
+});

--- a/tests/examples/CustomMarkup.svelte
+++ b/tests/examples/CustomMarkup.svelte
@@ -1,0 +1,9 @@
+<script>
+  import Time from "svelte-time";
+</script>
+
+<Time relative timestamp="2024-01-01">
+  {#snippet children(formatted)}
+    <strong>{formatted}</strong>
+  {/snippet}
+</Time>

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,4 @@
-if (
-  typeof window !== "undefined" &&
-  !("innerText" in HTMLElement.prototype)
-) {
+if (typeof window !== "undefined" && !("innerText" in HTMLElement.prototype)) {
   Object.defineProperty(HTMLElement.prototype, "innerText", {
     configurable: true,
     enumerable: true,

--- a/tests/ssr/Time.ssr.test.ts
+++ b/tests/ssr/Time.ssr.test.ts
@@ -1,5 +1,6 @@
 import { render } from "svelte/server";
 import Time, { dayjs } from "svelte-time";
+import TimeChildren from "./TimeChildren.ssr.test.svelte";
 
 describe("Time (SSR)", () => {
   const TS = "2024-01-01T00:00:00.000Z";
@@ -28,6 +29,13 @@ describe("Time (SSR)", () => {
     render(Time, { props: { timestamp: TS, relative: true, live: true } });
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  test("children snippet renders custom markup in the server HTML", () => {
+    const { body } = render(TimeChildren, { props: { timestamp: TS } });
+    expect(body).toContain(
+      `<strong>${dayjs(TS).format("MMM DD, YYYY")}</strong>`,
+    );
   });
 
   test("never renders 'Invalid Date' for valid inputs", () => {

--- a/tests/ssr/TimeChildren.ssr.test.svelte
+++ b/tests/ssr/TimeChildren.ssr.test.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Time from "svelte-time";
+
+  let { timestamp }: { timestamp: string } = $props();
+</script>
+
+<Time {timestamp}>
+  {#snippet children(formatted)}
+    <strong>{formatted}</strong>
+  {/snippet}
+</Time>

--- a/tests/types.test-d.ts
+++ b/tests/types.test-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from "vitest";
+import type { Snippet } from "svelte";
 import type { TimeProps, SvelteTimeOptions, Locales } from "svelte-time";
 
 test("format is a plain string", () => {
@@ -14,4 +15,14 @@ test("formatted is not a prop", () => {
 test("action options are exported and include title", () => {
   expectTypeOf<SvelteTimeOptions["title"]>().not.toBeNever();
   expectTypeOf<Locales>().toExtend<string>();
+});
+
+test("children accepts a snippet receiving the formatted string", () => {
+  expectTypeOf<TimeProps["children"]>().toEqualTypeOf<
+    Snippet<[string]> | undefined
+  >();
+
+  // @ts-expect-error — a Snippet<[number]> is not assignable to Snippet<[string]>
+  const props: TimeProps = { children: (() => {}) as Snippet<[number]> };
+  void props;
 });


### PR DESCRIPTION
The component always rendered the formatted value as bare text, so any
custom markup (bold, icons, styled spans) meant abandoning the
component and rebuilding its formatting on the raw dayjs export. A
children snippet now receives the reactive formatted string while the
component keeps owning the semantic <time> element, title, and
datetime handling:

  <Time relative timestamp={post.createdAt}>
    {#snippet children(formatted)}
      <strong>{formatted}</strong>
    {/snippet}
  </Time>

Live updates and prop changes re-render the snippet automatically.
Rendering without a snippet is byte-for-byte unchanged.