### PR TITLE
feat: add time attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,37 @@ Specify a custom update interval using the `live` prop.
 ></time>
 ```
 
+### `time` attachment
+
+[Attachments](https://svelte.dev/docs/svelte/@attach) (the `@attach` directive, Svelte 5.29+) are the successor to actions. The `time` attachment is an alternative to the `svelteTime` action with fully reactive options: it re-runs whenever any reactive value used to build its options changes, including options built inline in the template. In `live` mode, it shares the same global timer as the `Time` component instead of owning a `setInterval` per element.
+
+<!-- render:TimeAttachment -->
+
+```svelte
+<script>
+  import { time } from "svelte-time";
+</script>
+
+<time {@attach time({ timestamp: "2021-02-02", format: "YYYY-MM-DD" })}></time>
+```
+
+Because options are reactive, an inline options object built from `$state` updates the element automatically, with no `update()` contract required:
+
+<!-- render:TimeAttachmentReactive -->
+
+```svelte
+<script lang="ts">
+  import { time } from "svelte-time";
+
+  let timestamp = $state("2021-02-02");
+</script>
+
+<time {@attach time({ timestamp, format: "YYYY-MM-DD" })}></time>
+<button onclick={() => (timestamp = "2021-02-03")}>Update</button>
+```
+
+The `@attach` directive requires Svelte 5.29+ to use. The `svelteTime` action remains fully supported.
+
 ### Remove "ago" suffix
 
 Set `withoutSuffix` to `true` to remove the "ago" suffix from relative time.

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -45,18 +45,9 @@
 
   import { dayjs } from "./dayjs";
   import { toDatetime } from "./datetime";
-  import { sharedNow } from "./ticker";
+  import { liveInterval, sharedNow } from "./ticker";
 
   const canTick = typeof document !== "undefined";
-
-  /** Update interval appropriate to the timestamp's age. */
-  function liveInterval(ageMs) {
-    const age = Math.abs(ageMs);
-    if (age < 60_000) return 10_000; // seconds-old: tick every 10s
-    if (age < 3_600_000) return 30_000; // minutes-old: every 30s
-    if (age < 86_400_000) return 300_000; // hours-old: every 5 min
-    return 3_600_000; // days-old and beyond: hourly
-  }
 
   /**
    * Get the effective locale to use.

--- a/src/attachment.d.ts
+++ b/src/attachment.d.ts
@@ -1,0 +1,6 @@
+import type { Attachment } from "svelte/attachments";
+import type { SvelteTimeOptions } from "./svelte-time.svelte";
+
+export function time(
+  options?: Partial<SvelteTimeOptions>,
+): Attachment<HTMLElement>;

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -1,0 +1,75 @@
+import { dayjs } from "./dayjs";
+import { toDatetime } from "./datetime";
+import { liveInterval, sharedNow } from "./ticker";
+
+const DEFAULT_INTERVAL = 60 * 1_000;
+
+/**
+ * Attachment version of `svelteTime`. Options are reactive: the
+ * attachment re-runs when any reactive value used to build `options`
+ * changes, and live mode subscribes to the shared ticker.
+ *
+ * @param {Partial<import("./svelte-time.svelte").SvelteTimeOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach time({ relative: true, timestamp })}></time>
+ */
+export function time(options = {}) {
+  return (node) => {
+    const timestamp = options.timestamp ?? new Date().toISOString();
+    const format = options.format || "MMM DD, YYYY";
+    const relative = options.relative === true;
+    const withoutSuffix = options.withoutSuffix ?? false;
+    const live = options.live ?? false;
+    let locale = options.locale ?? "en";
+
+    // If locale is default "en" and timestamp is a dayjs instance with a locale set,
+    // preserve the timestamp's locale for backward compatibility
+    if (
+      locale === "en" &&
+      timestamp &&
+      typeof timestamp === "object" &&
+      "$L" in timestamp
+    ) {
+      const timestampLocale = timestamp.$L;
+      if (timestampLocale && timestampLocale !== "en") {
+        locale = timestampLocale;
+      }
+    }
+
+    const day = dayjs(timestamp).locale(locale);
+
+    let now = dayjs();
+    if (relative && live !== false) {
+      // Reading sharedNow subscribes this attachment to the shared
+      // clock; each tick re-runs the whole attachment. Tier selection
+      // uses a fresh age each run so components migrate tiers
+      // naturally on re-run, with no state and no cycles.
+      const interval =
+        typeof live === "number"
+          ? Math.abs(live)
+          : live === true
+            ? liveInterval(day.diff(dayjs()))
+            : DEFAULT_INTERVAL;
+      now = sharedNow(interval);
+    }
+
+    if (relative) {
+      if ("title" in options) {
+        if (options.title !== undefined) {
+          node.setAttribute("title", options.title);
+        }
+      } else {
+        node.setAttribute("title", day.format(format));
+      }
+    } else {
+      node.removeAttribute("title");
+    }
+
+    const datetime = toDatetime(timestamp);
+    if (datetime) node.setAttribute("datetime", datetime);
+    else node.removeAttribute("datetime");
+    node.textContent = relative
+      ? day.from(now, withoutSuffix)
+      : day.format(format);
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
+export { time } from "./attachment";
 export { dayjs } from "./dayjs";
 export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { time } from "./attachment";
 export { dayjs } from "./dayjs";
 export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";

--- a/src/ticker.d.ts
+++ b/src/ticker.d.ts
@@ -5,3 +5,6 @@ import type { Dayjs } from "dayjs";
  * re-runs on every tick of the shared timer for `intervalMs`.
  */
 export declare function sharedNow(intervalMs: number): Dayjs;
+
+/** Update interval appropriate to the timestamp's age. */
+export declare function liveInterval(ageMs: number): number;

--- a/src/ticker.js
+++ b/src/ticker.js
@@ -9,6 +9,19 @@ import { dayjs } from "./dayjs";
 const tickers = new Map();
 
 /**
+ * Update interval appropriate to the timestamp's age.
+ * @param {number} ageMs
+ * @returns {number}
+ */
+export function liveInterval(ageMs) {
+  const age = Math.abs(ageMs);
+  if (age < 60_000) return 10_000; // seconds-old: tick every 10s
+  if (age < 3_600_000) return 30_000; // minutes-old: every 30s
+  if (age < 86_400_000) return 300_000; // hours-old: every 5 min
+  return 3_600_000; // days-old and beyond: hourly
+}
+
+/**
  * Reactive "now". When read inside an effect or derived, the caller
  * re-runs on every tick of the shared timer for `intervalMs`.
  * @param {number} intervalMs

--- a/tests/SvelteTimeAttachment.test.ts
+++ b/tests/SvelteTimeAttachment.test.ts
@@ -1,0 +1,91 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import TimeAttachment from "./examples/TimeAttachment.svelte";
+import TimeAttachmentReactive from "./examples/TimeAttachmentReactive.svelte";
+import SvelteTimeAttachmentLive from "./SvelteTimeAttachmentLive.test.svelte";
+import SvelteTimeAttachmentTitle from "./SvelteTimeAttachmentTitle.test.svelte";
+
+describe("time attachment", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("basic render: textContent and datetime are correct", () => {
+    const target = document.body;
+    instance = mount(TimeAttachment, { target });
+    flushSync();
+
+    const element = getElement("time");
+    expect(element.textContent).toEqual("2021-02-02");
+    expect(element.getAttribute("datetime")).toEqual("2021-02-02");
+  });
+
+  test("reactivity: re-runs when a reactive value used to build options changes", () => {
+    const target = document.body;
+    instance = mount(TimeAttachmentReactive, { target });
+    flushSync();
+
+    const element = getElement("time");
+    expect(element.textContent).toEqual("2021-02-02");
+    expect(element.getAttribute("datetime")).toEqual("2021-02-02");
+
+    const button = getElement("button");
+    button.click();
+    flushSync();
+
+    expect(element.textContent).toEqual("2021-02-03");
+    expect(element.getAttribute("datetime")).toEqual("2021-02-03");
+  });
+
+  test("relative + title parity: custom title is kept, omitted title clears the attribute", () => {
+    const target = document.body;
+    instance = mount(SvelteTimeAttachmentTitle, { target });
+    flushSync();
+
+    const customTitle = getElement('[data-test="attachment-custom-title"]');
+    const omittedTitle = getElement(
+      '[data-test="attachment-custom-title-omit"]',
+    );
+
+    expect(customTitle.title).toEqual("Custom title");
+    expect(omittedTitle.title).toEqual("");
+  });
+
+  test("live sharing: two attachment elements with the same interval share one timer", async () => {
+    const spy = vi.spyOn(global, "setInterval");
+    const target = document.body;
+    instance = mount(SvelteTimeAttachmentLive, { target });
+    flushSync();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    const elementA = getElement('[data-test="attachment-live-a"]');
+    const elementB = getElement('[data-test="attachment-live-b"]');
+    expect(elementA.textContent).toEqual("a few seconds ago");
+    expect(elementB.textContent).toEqual("a few seconds ago");
+
+    vi.runOnlyPendingTimers(); // 30 seconds
+    await tick();
+    vi.runOnlyPendingTimers(); // 60 seconds
+    await tick();
+
+    expect(elementA.textContent).toEqual("a minute ago");
+    expect(elementB.textContent).toEqual("a minute ago");
+  });
+});

--- a/tests/SvelteTimeAttachmentLive.test.svelte
+++ b/tests/SvelteTimeAttachmentLive.test.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { time } from "svelte-time";
+
+  const CUSTOM_INTERVAL = 30 * 1_000;
+  const timestamp = new Date().toISOString();
+</script>
+
+<time
+  data-test="attachment-live-a"
+  {@attach time({ relative: true, live: CUSTOM_INTERVAL, timestamp })}
+></time>
+
+<time
+  data-test="attachment-live-b"
+  {@attach time({ relative: true, live: CUSTOM_INTERVAL, timestamp })}
+></time>

--- a/tests/SvelteTimeAttachmentTitle.test.svelte
+++ b/tests/SvelteTimeAttachmentTitle.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { time } from "svelte-time";
+</script>
+
+<time
+  data-test="attachment-custom-title"
+  {@attach time({
+    relative: true,
+    timestamp: "2021-02-02",
+    title: "Custom title",
+  })}
+></time>
+
+<time
+  data-test="attachment-custom-title-omit"
+  {@attach time({
+    relative: true,
+    timestamp: "2021-02-02",
+    title: undefined,
+  })}
+></time>

--- a/tests/examples/TimeAttachment.svelte
+++ b/tests/examples/TimeAttachment.svelte
@@ -1,0 +1,5 @@
+<script>
+  import { time } from "svelte-time";
+</script>
+
+<time {@attach time({ timestamp: "2021-02-02", format: "YYYY-MM-DD" })}></time>

--- a/tests/examples/TimeAttachmentReactive.svelte
+++ b/tests/examples/TimeAttachmentReactive.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { time } from "svelte-time";
+
+  let timestamp = $state("2021-02-02");
+</script>
+
+<time {@attach time({ timestamp, format: "YYYY-MM-DD" })}></time>
+<button onclick={() => (timestamp = "2021-02-03")}>Update</button>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,10 @@
 import * as API from "svelte-time";
 
 test("Library has exports", () => {
-  expect(Object.keys(API).sort()).toEqual(["dayjs", "default", "svelteTime"]);
+  expect(Object.keys(API).sort()).toEqual([
+    "dayjs",
+    "default",
+    "svelteTime",
+    "time",
+  ]);
 });

--- a/tests/ssr/TimeAttachment.ssr.test.ts
+++ b/tests/ssr/TimeAttachment.ssr.test.ts
@@ -1,0 +1,17 @@
+import { render } from "svelte/server";
+import TimeAttachment from "../examples/TimeAttachment.svelte";
+import SvelteTimeAttachmentLive from "../SvelteTimeAttachmentLive.test.svelte";
+
+describe("time attachment (SSR)", () => {
+  test("renders an empty <time> element on the server", () => {
+    const { body } = render(TimeAttachment);
+    expect(body).toContain("<time></time>");
+  });
+
+  test("live mode starts no timers on the server", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    render(SvelteTimeAttachmentLive);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/tests/types.test-d.ts
+++ b/tests/types.test-d.ts
@@ -1,4 +1,6 @@
 import { expectTypeOf, test } from "vitest";
+import { time } from "svelte-time";
+import type { Attachment } from "svelte/attachments";
 import type { TimeProps, SvelteTimeOptions, Locales } from "svelte-time";
 
 test("format is a plain string", () => {
@@ -14,4 +16,11 @@ test("formatted is not a prop", () => {
 test("action options are exported and include title", () => {
   expectTypeOf<SvelteTimeOptions["title"]>().not.toBeNever();
   expectTypeOf<Locales>().toExtend<string>();
+});
+
+test("time attachment returns an Attachment<HTMLElement>", () => {
+  expectTypeOf(time()).toEqualTypeOf<Attachment<HTMLElement>>();
+  expectTypeOf(time)
+    .parameter(0)
+    .toEqualTypeOf<Partial<SvelteTimeOptions> | undefined>();
 });


### PR DESCRIPTION
## Summary
- Adds a `time` attachment (Svelte 5.29+ `{@attach ...}`) as a reactive alternative to the `svelteTime` action: `<time {@attach time({ relative: true, timestamp })}></time>`
- Options are fully reactive (re-runs on any reactive value read while building them, including inline template options), and `live` mode subscribes to the shared ticker so attachment elements share the one-timer-per-interval / adaptive scheduling model instead of owning a `setInterval` each
- Extracts `liveInterval` (the age-to-interval tier function) out of `Time.svelte` into `src/ticker.js` so both the component and the attachment share one tier table
- `svelteTime` action is unchanged and remains fully supported; `{@attach}` requires Svelte 5.29+, peer range is unchanged since the attachment is a plain-function runtime with type-only imports
