### PR TITLE
feat: add `tz` prop for per-instance timezone conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,29 @@ To set a global default locale:
 </script>
 ```
 
+### tz prop
+
+Pass a `tz` prop to render a timestamp in a given [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) without pre-building a `dayjs.tz(...)` value yourself. This requires the `utc` and `timezone` plugins from `dayjs` to be extended; if they're missing, `tz` throws a clear error instead of failing silently.
+
+<!-- render:TzProp -->
+
+```svelte
+<script>
+  import utc from "dayjs/plugin/utc";
+  import timezone from "dayjs/plugin/timezone";
+  import Time, { dayjs } from "svelte-time";
+
+  dayjs.extend(utc);
+  dayjs.extend(timezone);
+</script>
+
+<Time
+  timestamp="2013-11-18T11:55:20Z"
+  tz="America/Toronto"
+  format="YYYY-MM-DDTHH:mm:ss"
+/>
+```
+
 ### Custom timezone
 
 To use a [custom timezone](https://day.js.org/docs/en/timezone/timezone), import the `utc` and `timezone` plugins from `dayjs`.
@@ -533,6 +556,10 @@ Use the [`dayjs.tz.setDefault`](https://day.js.org/docs/en/timezone/default-time
   dayjs.tz.setDefault("America/New_York");
 </script>
 ```
+
+> **Note:** `dayjs.tz.setDefault(...)` only affects values built with `dayjs.tz(...)` — it does
+> not change what `<Time>` renders by itself. Use the `tz` prop (above) for the common case, or
+> pass `timestamp={dayjs.tz(value)}` explicitly if you're relying on a global default.
 
 ### User timezone
 
@@ -581,6 +608,7 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 | withoutSuffix | `boolean`                                             | `false` (only applies when `relative` is `true`)                                         |
 | live          | `boolean` &#124; `number`                             | `false`                                                                                  |
 | locale        | `Locales` (TypeScript) &#124; `string`                | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))    |
+| tz            | `string`                                              | `undefined` (See [tz prop](#tz-prop); requires the dayjs `utc`/`timezone` plugins)       |
 | children      | `Snippet<[string]>`                                   | `undefined`                                                                              |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -559,7 +559,8 @@ Use the [`dayjs.tz.setDefault`](https://day.js.org/docs/en/timezone/default-time
 
 > **Note:** `dayjs.tz.setDefault(...)` only affects values built with `dayjs.tz(...)` — it does
 > not change what `<Time>` renders by itself. Use the `tz` prop (above) for the common case, or
-> pass `timestamp={dayjs.tz(value)}` explicitly if you're relying on a global default.
+> pass a `dayjs.tz(value)` result as the `timestamp` prop explicitly if you're relying on a
+> global default.
 
 ### User timezone
 

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -42,6 +42,13 @@
     locale = "en",
 
     /**
+     * IANA timezone name (e.g. "America/New_York") to render the timestamp
+     * in. Requires the dayjs `utc` and `timezone` plugins to be extended.
+     * @type {string | undefined}
+     */
+    tz = undefined,
+
+    /**
      * Snippet rendered inside the `time` element instead of the plain
      * formatted string. Receives the formatted value as its argument.
      * @type {import("svelte").Snippet<[string]> | undefined}
@@ -76,10 +83,21 @@
   });
 
   /**
-   * Parsed timestamp with the effective locale applied.
+   * Parsed timestamp with the timezone (if provided) and effective locale
+   * applied.
    * @type {import("dayjs").Dayjs}
    */
-  const day = $derived(dayjs(timestamp).locale(effectiveLocale));
+  const day = $derived.by(() => {
+    const base = dayjs(timestamp);
+    if (tz === undefined) return base.locale(effectiveLocale);
+    if (typeof base.tz !== "function") {
+      throw new Error(
+        "svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins — " +
+          "see https://github.com/metonym/svelte-time#custom-timezone",
+      );
+    }
+    return base.tz(tz).locale(effectiveLocale);
+  });
 
   // Tier for adaptive `live === true` scheduling. Written from an effect
   // (rather than derived directly from `now`) to avoid a `$derived` cycle:

--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -47,6 +47,16 @@ export interface TimeProps extends RestProps {
   locale?: Locales;
 
   /**
+   * IANA timezone name (e.g. "America/New_York") to render the
+   * timestamp in. Requires the dayjs `utc` and `timezone` plugins to be
+   * extended by the consumer — throws at runtime otherwise. Left
+   * `undefined` (the default), the timestamp renders in the browser's
+   * local timezone, matching dayjs's own default behavior.
+   * @default undefined
+   */
+  tz?: string;
+
+  /**
    * Snippet rendered inside the `time` element instead of the plain
    * formatted string. Receives the formatted value as its argument.
    */

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -20,6 +20,7 @@ export function time(options = {}) {
     const relative = options.relative === true;
     const withoutSuffix = options.withoutSuffix ?? false;
     const live = options.live ?? false;
+    const tz = options.tz;
     let locale = options.locale ?? "en";
 
     // If locale is default "en" and timestamp is a dayjs instance with a locale set,
@@ -36,7 +37,14 @@ export function time(options = {}) {
       }
     }
 
-    const day = dayjs(timestamp).locale(locale);
+    const base = dayjs(timestamp);
+    if (tz !== undefined && typeof base.tz !== "function") {
+      throw new Error(
+        "svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins — " +
+          "see https://github.com/metonym/svelte-time#custom-timezone",
+      );
+    }
+    const day = (tz === undefined ? base : base.tz(tz)).locale(locale);
 
     let now = dayjs();
     if (relative && live !== false) {

--- a/src/svelte-time.svelte.d.ts
+++ b/src/svelte-time.svelte.d.ts
@@ -10,6 +10,7 @@ export interface SvelteTimeOptions extends Pick<
   | "live"
   | "title"
   | "locale"
+  | "tz"
 > {}
 
 export const svelteTime: Action<

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -21,6 +21,7 @@ export const svelteTime = (node, options = {}) => {
     const relative = options.relative === true;
     const withoutSuffix = options.withoutSuffix ?? false;
     const live = options.live ?? false;
+    const tz = options.tz;
     let locale = options.locale ?? "en";
 
     // If locale is default "en" and timestamp is a dayjs instance with a locale set,
@@ -37,29 +38,36 @@ export const svelteTime = (node, options = {}) => {
       }
     }
 
-    let formatted = dayjs(timestamp).locale(locale).format(format);
+    const getDay = () => {
+      const base = dayjs(timestamp);
+      if (tz === undefined) return base.locale(locale);
+      if (typeof base.tz !== "function") {
+        throw new Error(
+          "svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins — " +
+            "see https://github.com/metonym/svelte-time#custom-timezone",
+        );
+      }
+      return base.tz(tz).locale(locale);
+    };
+
+    let formatted = getDay().format(format);
 
     if (relative) {
       // Use dayjs's built-in withoutSuffix parameter (locale-aware)
-      formatted = dayjs(timestamp).locale(locale).from(dayjs(), withoutSuffix);
+      formatted = getDay().from(dayjs(), withoutSuffix);
 
       if ("title" in options) {
         if (options.title !== undefined) {
           node.setAttribute("title", options.title);
         }
       } else {
-        node.setAttribute(
-          "title",
-          dayjs(timestamp).locale(locale).format(format),
-        );
+        node.setAttribute("title", getDay().format(format));
       }
 
       if (live !== false) {
         interval = setInterval(
           () => {
-            node.textContent = dayjs(timestamp)
-              .locale(locale)
-              .from(dayjs(), withoutSuffix);
+            node.textContent = getDay().from(dayjs(), withoutSuffix);
           },
           Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
         );

--- a/tests/SvelteTimeParity.test.ts
+++ b/tests/SvelteTimeParity.test.ts
@@ -1,6 +1,11 @@
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
 import { flushSync, mount, unmount } from "svelte";
-import Time, { svelteTime } from "svelte-time";
+import Time, { svelteTime, time } from "svelte-time";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 describe("component/action parity for edge-case timestamps", () => {
   beforeEach(() => {
@@ -42,4 +47,42 @@ describe("component/action parity for edge-case timestamps", () => {
       unmount(instance);
     });
   }
+});
+
+describe("component/action/attachment parity for the tz prop", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("all three surfaces render an identical zoned value", () => {
+    const timestamp = "2013-11-18T11:55:20Z";
+    const format = "YYYY-MM-DDTHH:mm:ss";
+    const tz = "America/Toronto";
+    const expected = dayjs(timestamp).tz(tz).format(format);
+
+    const instance = mount(Time, {
+      target: document.body,
+      props: { "data-test": "component", timestamp, tz, format },
+    });
+    flushSync();
+
+    const actionNode = document.createElement("time");
+    document.body.appendChild(actionNode);
+    const action = svelteTime(actionNode, { timestamp, tz, format });
+
+    const attachmentNode = document.createElement("time");
+    document.body.appendChild(attachmentNode);
+    time({ timestamp, tz, format })(attachmentNode);
+
+    const componentText = document
+      .querySelector('[data-test="component"]')
+      ?.textContent?.trim();
+
+    expect(componentText).toEqual(expected);
+    expect(actionNode.textContent?.trim()).toEqual(expected);
+    expect(attachmentNode.textContent?.trim()).toEqual(expected);
+
+    action?.destroy?.();
+    unmount(instance);
+  });
 });

--- a/tests/Timezone.test.ts
+++ b/tests/Timezone.test.ts
@@ -1,0 +1,66 @@
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import { flushSync, mount, unmount } from "svelte";
+import Time, { dayjs } from "svelte-time";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+describe("tz prop", () => {
+  const TIMESTAMP = "2013-11-18T11:55:20Z";
+  const FORMAT = "YYYY-MM-DDTHH:mm:ss";
+  const ZONE = "America/Toronto";
+
+  let instance: null | ReturnType<typeof mount> = null;
+
+  afterEach(() => {
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  function render(props: Record<string, unknown>) {
+    instance = mount(Time, {
+      target: document.body,
+      props: { "data-test": "component", ...props },
+    });
+    flushSync();
+    return document.querySelector('[data-test="component"]') as HTMLElement;
+  }
+
+  test("basic conversion: renders the zone's local wall-clock time", () => {
+    const expected = dayjs(TIMESTAMP).tz(ZONE).format(FORMAT);
+
+    const element = render({ timestamp: TIMESTAMP, tz: ZONE, format: FORMAT });
+
+    expect(element.textContent).toEqual(expected);
+    // Sanity: the conversion actually changed the wall-clock value, so this
+    // assertion isn't vacuously true against the un-zoned format.
+    expect(expected).not.toEqual(dayjs(TIMESTAMP).format(FORMAT));
+  });
+
+  test("no tz: renders using plain dayjs(timestamp), unaffected", () => {
+    const expected = dayjs(TIMESTAMP).format(FORMAT);
+
+    const element = render({ timestamp: TIMESTAMP, format: FORMAT });
+
+    expect(element.textContent).toEqual(expected);
+  });
+
+  test("datetime attribute is unaffected by tz", () => {
+    const withoutTz = render({ timestamp: TIMESTAMP, format: FORMAT });
+    const datetimeWithoutTz = withoutTz.getAttribute("datetime");
+
+    unmount(instance as ReturnType<typeof mount>);
+    instance = null;
+    document.body.innerHTML = "";
+
+    const withTz = render({ timestamp: TIMESTAMP, tz: ZONE, format: FORMAT });
+    const datetimeWithTz = withTz.getAttribute("datetime");
+
+    expect(datetimeWithTz).toEqual(datetimeWithoutTz);
+    expect(datetimeWithTz).toEqual(TIMESTAMP);
+  });
+});

--- a/tests/TimezoneMissingPlugin.test.ts
+++ b/tests/TimezoneMissingPlugin.test.ts
@@ -1,0 +1,42 @@
+// Isolated in its own file: dayjs plugin extension mutates the shared
+// `dayjs` singleton (src/dayjs.js) for the lifetime of the Vitest worker, so
+// once any other test file extends `utc`/`timezone`, later files would see
+// those plugins as already present. `vi.resetModules()` + a dynamic import
+// gets a fresh, unextended copy regardless of suite execution order.
+describe("tz prop without utc/timezone plugins extended", () => {
+  // Re-importing Time.svelte/dayjs/svelte fresh after vi.resetModules() is
+  // slow under parallel worker contention; give it headroom beyond the 5s
+  // default to avoid flaking in CI.
+  test("throws a clear, actionable error", async () => {
+    vi.resetModules();
+
+    const { dayjs } = await import("../src/dayjs.js");
+    expect(typeof (dayjs() as any).tz).not.toEqual("function");
+
+    const { default: Time } = await import("../src/Time.svelte");
+    const { mount, flushSync, unmount } = await import("svelte");
+
+    let thrown: unknown;
+    let instance: ReturnType<typeof mount> | undefined;
+    try {
+      instance = mount(Time, {
+        target: document.body,
+        props: {
+          timestamp: "2013-11-18T11:55:20Z",
+          tz: "America/Toronto",
+        },
+      });
+      flushSync();
+    } catch (error) {
+      thrown = error;
+    } finally {
+      if (instance) unmount(instance);
+      document.body.innerHTML = "";
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(
+      /svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins/,
+    );
+  }, 15_000);
+});

--- a/tests/examples/TzProp.svelte
+++ b/tests/examples/TzProp.svelte
@@ -1,0 +1,14 @@
+<script>
+  import utc from "dayjs/plugin/utc";
+  import timezone from "dayjs/plugin/timezone";
+  import Time, { dayjs } from "svelte-time";
+
+  dayjs.extend(utc);
+  dayjs.extend(timezone);
+</script>
+
+<Time
+  timestamp="2013-11-18T11:55:20Z"
+  tz="America/Toronto"
+  format="YYYY-MM-DDTHH:mm:ss"
+/>


### PR DESCRIPTION
Adds a tz prop to the Time component, svelteTime action, and time attachment that renders a timestamp in a given IANA timezone by calling dayjs's .tz() before formatting, e.g. <Time tz="America/Toronto" timestamp="2013-11-18T11:55:20Z" />.

This closes #74, where calling dayjs.tz.setDefault(zone) didn't affect what Time rendered. That's expected dayjs behavior since setDefault only patches dayjs.tz(...) calls, not the plain dayjs() constructor Time uses internally, but there was previously no way to say "render this in zone X" without manually building a dayjs.tz(...) value and re-deriving it on every reactive update. The tz prop removes that footgun.

Consumers still need to extend dayjs's utc and timezone plugins themselves, consistent with the existing bundle-size policy of only shipping relativeTime by default. Passing tz without those plugins throws a clear, actionable error instead of failing with a cryptic TypeError or silently rendering the wrong time. The three entry points (component, action, attachment) apply the same conversion and error guard at the point each turns timestamp into a dayjs instance, and a parity test asserts they render identically.

Main risk area is the missing-plugin error path, since it depends on module state (extending utc/timezone mutates the shared dayjs singleton for the life of the test worker). That's covered by an isolated test using vi.resetModules() plus a dynamic import to get an unextended dayjs copy regardless of suite order. The datetime attribute is unaffected by tz, since it reflects the same absolute instant regardless of display zone; that's covered by a dedicated test too.