### PR TITLE
feat: add `relativeThreshold` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ To force a fixed interval instead, pass a value to `live` in milliseconds (ms).
 <Time live={10 * 60 * 1_000} relative />
 ```
 
+### Auto-switch to absolute format
+
+Set `relativeThreshold` (age in ms) to switch from `relative` to the absolute `format` once a timestamp gets old enough. Only takes effect while `relative` is `true`. Combined with `live`, the switch happens automatically as time passes; without `live`, `relativeThreshold` only affects the value computed at render time.
+
+<!-- render:RelativeThreshold -->
+
+```svelte
+<!-- Shows "a minute ago", flips to "4:40 am" after 2 hours -->
+<Time relative live format="h:mm a" relativeThreshold={2 * 60 * 60 * 1000} />
+```
+
 ### `svelteTime` action
 
 An alternative to the `Time` component is to use the `svelteTime` action to format a timestamp in a raw HTML element.
@@ -270,6 +281,19 @@ Specify a custom update interval using the `live` prop.
 ></time>
 ```
 
+Use `relativeThreshold` to switch to the absolute `format` once the timestamp's age (ms) meets or exceeds it.
+
+```svelte
+<time
+  use:svelteTime={{
+    relative: true,
+    live: true,
+    format: "h:mm a",
+    relativeThreshold: 2 * 60 * 60 * 1_000, // 2 hours
+  }}
+></time>
+```
+
 ### `time` attachment
 
 [Attachments](https://svelte.dev/docs/svelte/@attach) (the `@attach` directive, Svelte 5.29+) are the successor to actions. The `time` attachment is an alternative to the `svelteTime` action with fully reactive options: it re-runs whenever any reactive value used to build its options changes, including options built inline in the template. In `live` mode, it shares the same global timer as the `Time` component instead of owning a `setInterval` per element.
@@ -300,6 +324,19 @@ Because options are reactive, an inline options object built from `$state` updat
 ```
 
 The `@attach` directive requires Svelte 5.29+ to use. The `svelteTime` action remains fully supported.
+
+`relativeThreshold` works the same way as the `Time` component and `svelteTime` action:
+
+```svelte
+<time
+  {@attach time({
+    relative: true,
+    live: true,
+    format: "h:mm a",
+    relativeThreshold: 2 * 60 * 60 * 1_000, // 2 hours
+  })}
+></time>
+```
 
 ### Remove "ago" suffix
 

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -57,6 +57,13 @@
     tz = undefined,
 
     /**
+     * When `relative` is `true`, switch to displaying `format` once the
+     * timestamp's age (in ms) meets or exceeds this value.
+     * @type {number | undefined}
+     */
+    relativeThreshold = undefined,
+
+    /**
      * Snippet rendered inside the `time` element instead of the plain
      * formatted string. Receives the formatted value as its argument.
      * @type {import("svelte").Snippet<[string]> | undefined}
@@ -134,12 +141,22 @@
   );
 
   /**
+   * Whether the timestamp's age has met or exceeded `relativeThreshold`,
+   * in which case `relative` display gives way to `format`.
+   * @type {boolean}
+   */
+  const isPastThreshold = $derived(
+    relativeThreshold != null &&
+      Math.abs(day.diff(live !== false ? now : dayjs())) >= relativeThreshold,
+  );
+
+  /**
    * Formatted timestamp.
    * Result of invoking `dayjs().format()` or `dayjs().from()`
    * @type {string}
    */
   let formatted = $derived(
-    relative
+    relative && !isPastThreshold
       ? relativeStyle === "micro"
         ? microFormat(day.diff(live !== false ? now : dayjs()))
         : day.from(live !== false ? now : dayjs(), withoutSuffix)
@@ -151,7 +168,9 @@
    * Result of invoking `dayjs().format()`
    * @type {string | undefined}
    */
-  const title = $derived(relative ? day.format(format) : undefined);
+  const title = $derived(
+    relative && !isPastThreshold ? day.format(format) : undefined,
+  );
 </script>
 
 {#if children}

--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -74,6 +74,14 @@ export interface TimeProps extends RestProps {
   tz?: string;
 
   /**
+   * When `relative` is `true`, switch to displaying `format` once the
+   * timestamp's age (in ms) meets or exceeds this value. Left `undefined`
+   * (the default), relative display never expires.
+   * @default undefined
+   */
+  relativeThreshold?: number;
+
+  /**
    * Snippet rendered inside the `time` element instead of the plain
    * formatted string. Receives the formatted value as its argument.
    */

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -23,6 +23,7 @@ export function time(options = {}) {
     const relativeStyle = options.relativeStyle ?? "default";
     const live = options.live ?? false;
     const tz = options.tz;
+    const relativeThreshold = options.relativeThreshold;
     let locale = options.locale ?? "en";
 
     // If locale is default "en" and timestamp is a dayjs instance with a locale set,
@@ -63,7 +64,11 @@ export function time(options = {}) {
       now = sharedNow(interval);
     }
 
-    if (relative) {
+    const isPastThreshold =
+      relativeThreshold != null && Math.abs(day.diff(now)) >= relativeThreshold;
+    const showRelative = relative && !isPastThreshold;
+
+    if (showRelative) {
       if ("title" in options) {
         if (options.title !== undefined) {
           node.setAttribute("title", options.title);
@@ -78,7 +83,7 @@ export function time(options = {}) {
     const datetime = toDatetime(timestamp);
     if (datetime) node.setAttribute("datetime", datetime);
     else node.removeAttribute("datetime");
-    node.textContent = relative
+    node.textContent = showRelative
       ? relativeStyle === "micro"
         ? microFormat(day.diff(now))
         : day.from(now, withoutSuffix)

--- a/src/svelte-time.svelte.d.ts
+++ b/src/svelte-time.svelte.d.ts
@@ -12,6 +12,7 @@ export interface SvelteTimeOptions extends Pick<
   | "title"
   | "locale"
   | "tz"
+  | "relativeThreshold"
 > {}
 
 export const svelteTime: Action<

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -24,6 +24,7 @@ export const svelteTime = (node, options = {}) => {
     const relativeStyle = options.relativeStyle ?? "default";
     const live = options.live ?? false;
     const tz = options.tz;
+    const relativeThreshold = options.relativeThreshold;
     let locale = options.locale ?? "en";
 
     // If locale is default "en" and timestamp is a dayjs instance with a locale set,
@@ -52,9 +53,13 @@ export const svelteTime = (node, options = {}) => {
       return base.tz(tz).locale(locale);
     };
 
+    const isPastThreshold = (at) =>
+      relativeThreshold != null &&
+      Math.abs(getDay().diff(at)) >= relativeThreshold;
+
     let formatted = getDay().format(format);
 
-    if (relative) {
+    if (relative && !isPastThreshold(dayjs())) {
       formatted =
         relativeStyle === "micro"
           ? microFormat(getDay().diff(dayjs()))
@@ -72,10 +77,16 @@ export const svelteTime = (node, options = {}) => {
       if (live !== false) {
         interval = setInterval(
           () => {
+            const now = dayjs();
+            if (isPastThreshold(now)) {
+              node.textContent = getDay().format(format);
+              node.removeAttribute("title");
+              return;
+            }
             node.textContent =
               relativeStyle === "micro"
-                ? microFormat(getDay().diff(dayjs()))
-                : getDay().from(dayjs(), withoutSuffix);
+                ? microFormat(getDay().diff(now))
+                : getDay().from(now, withoutSuffix);
           },
           Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
         );

--- a/tests/RelativeThreshold.test.svelte
+++ b/tests/RelativeThreshold.test.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import Time, { svelteTime, time } from "svelte-time";
+
+  const THRESHOLD = 2 * 60 * 1_000; // 2 minutes, matches RelativeThreshold.test.ts
+
+  const fresh = new Date().toISOString();
+  const alreadyOld = new Date(Date.now() - THRESHOLD * 2).toISOString();
+</script>
+
+<Time
+  data-test="component-threshold"
+  relative
+  live
+  format="h:mm a"
+  relativeThreshold={THRESHOLD}
+  timestamp={fresh}
+/>
+
+<Time data-test="component-default" relative live timestamp={fresh} />
+
+<Time
+  data-test="component-already-past"
+  relative
+  live
+  format="h:mm a"
+  relativeThreshold={THRESHOLD}
+  timestamp={alreadyOld}
+/>
+
+<time
+  data-test="action-threshold"
+  use:svelteTime={{
+    relative: true,
+    live: true,
+    format: "h:mm a",
+    relativeThreshold: THRESHOLD,
+    timestamp: fresh,
+  }}
+></time>
+
+<time
+  data-test="attachment-threshold"
+  {@attach time({
+    relative: true,
+    live: true,
+    format: "h:mm a",
+    relativeThreshold: THRESHOLD,
+    timestamp: fresh,
+  })}
+></time>

--- a/tests/RelativeThreshold.test.ts
+++ b/tests/RelativeThreshold.test.ts
@@ -1,0 +1,108 @@
+import dayjs from "dayjs";
+import { flushSync, mount, tick, unmount } from "svelte";
+import RelativeThreshold from "./RelativeThreshold.test.svelte";
+
+describe("relativeThreshold", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+  const THRESHOLD = 2 * 60 * 1_000; // 2 minutes, matches RelativeThreshold.test.svelte
+  const FORMAT = "h:mm a";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("under threshold: renders relative text with an absolute title", () => {
+    instance = mount(RelativeThreshold, { target: document.body });
+    flushSync();
+
+    for (const selector of [
+      '[data-test="component-threshold"]',
+      '[data-test="action-threshold"]',
+      '[data-test="attachment-threshold"]',
+    ]) {
+      const element = getElement(selector);
+      expect(/ago/.test(element.textContent ?? "")).toEqual(true);
+      expect(element.title).toEqual(dayjs(FIXED_DATE).format(FORMAT));
+    }
+  });
+
+  test("already past threshold at mount: shows absolute format immediately, no relative flash", () => {
+    instance = mount(RelativeThreshold, { target: document.body });
+    flushSync();
+
+    const element = getElement('[data-test="component-already-past"]');
+    const alreadyOld = dayjs(FIXED_DATE).subtract(2 * THRESHOLD, "millisecond");
+    expect(element.textContent).toEqual(alreadyOld.format(FORMAT));
+    expect(element.title).toBeFalsy();
+  });
+
+  test("crosses threshold while mounted: flips from relative to absolute, live", async () => {
+    instance = mount(RelativeThreshold, { target: document.body });
+    flushSync();
+
+    const component = getElement('[data-test="component-threshold"]');
+    const action = getElement('[data-test="action-threshold"]');
+    const attachment = getElement('[data-test="attachment-threshold"]');
+
+    expect(/ago/.test(component.textContent ?? "")).toEqual(true);
+    expect(/ago/.test(action.textContent ?? "")).toEqual(true);
+    expect(/ago/.test(attachment.textContent ?? "")).toEqual(true);
+
+    // Still under the 2-minute threshold.
+    vi.advanceTimersByTime(THRESHOLD / 2);
+    await tick();
+    expect(/ago/.test(component.textContent ?? "")).toEqual(true);
+    expect(/ago/.test(action.textContent ?? "")).toEqual(true);
+    expect(/ago/.test(attachment.textContent ?? "")).toEqual(true);
+
+    // Crosses the threshold.
+    vi.advanceTimersByTime(THRESHOLD);
+    await tick();
+
+    // The absolute display formats the original timestamp (FIXED_DATE),
+    // not "now" — crossing the threshold doesn't change what's shown.
+    const expected = dayjs(FIXED_DATE).format(FORMAT);
+
+    expect(component.textContent).toEqual(expected);
+    expect(component.title).toBeFalsy();
+
+    expect(action.textContent).toEqual(expected);
+    expect(action.title).toBeFalsy();
+
+    expect(attachment.textContent).toEqual(expected);
+    expect(attachment.title).toBeFalsy();
+  });
+
+  test("default (relativeThreshold unset): existing relative behavior is unaffected", async () => {
+    instance = mount(RelativeThreshold, { target: document.body });
+    flushSync();
+
+    const element = getElement('[data-test="component-default"]');
+    expect(/ago/.test(element.textContent ?? "")).toEqual(true);
+    expect(element.title).toBeTruthy();
+
+    // Advance well past what would be a threshold in the other cases.
+    vi.advanceTimersByTime(THRESHOLD * 2);
+    await tick();
+
+    expect(/ago/.test(element.textContent ?? "")).toEqual(true);
+    expect(element.title).toBeTruthy();
+  });
+});

--- a/tests/SvelteTimeParity.test.ts
+++ b/tests/SvelteTimeParity.test.ts
@@ -1,11 +1,54 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
-import { flushSync, mount, unmount } from "svelte";
+import { flushSync, mount, tick, unmount } from "svelte";
 import Time, { svelteTime, time } from "svelte-time";
+import RelativeThreshold from "./RelativeThreshold.test.svelte";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
+
+describe("component/action parity for edge-case timestamps", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  const FORMAT = "YYYY-MM-DD";
+  const CASES: Array<[name: string, timestamp: unknown, expected: string]> = [
+    ["epoch (0)", 0, dayjs(0).format(FORMAT)],
+    ["empty string", "", "Invalid Date"],
+    ["date string", "2020-02-01", dayjs("2020-02-01").format(FORMAT)],
+  ];
+
+  for (const [name, timestamp, expected] of CASES) {
+    test(`${name}: component and action agree`, () => {
+      const instance = mount(Time, {
+        target: document.body,
+        props: { "data-test": "component", timestamp, format: FORMAT },
+      });
+      flushSync();
+
+      const node = document.createElement("time");
+      document.body.appendChild(node);
+      const action = svelteTime(node, { timestamp, format: FORMAT });
+
+      const componentText = document
+        .querySelector('[data-test="component"]')
+        ?.textContent?.trim();
+      expect(componentText).toEqual(expected);
+      expect(node.innerText?.trim()).toEqual(expected);
+
+      action?.destroy?.();
+      unmount(instance);
+    });
+  }
+});
 
 describe('component/action/attachment parity for relativeStyle="micro"', () => {
   beforeEach(() => {
@@ -52,7 +95,7 @@ describe('component/action/attachment parity for relativeStyle="micro"', () => {
   });
 });
 
-describe("component/action parity for edge-case timestamps", () => {
+describe("component/action/attachment parity for edge-case timestamps", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
@@ -128,6 +171,90 @@ describe("component/action/attachment parity for the tz prop", () => {
     expect(attachmentNode.textContent?.trim()).toEqual(expected);
 
     action?.destroy?.();
+    unmount(instance);
+  });
+});
+
+describe("component/action/attachment parity for relativeThreshold", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  const FORMAT = "h:mm a";
+  const THRESHOLD = 2 * 60 * 1_000;
+
+  test("static: component and action agree once already past the threshold", () => {
+    const timestamp = dayjs()
+      .subtract(2 * THRESHOLD, "millisecond")
+      .toISOString();
+    const expected = dayjs(timestamp).format(FORMAT);
+
+    const instance = mount(Time, {
+      target: document.body,
+      props: {
+        "data-test": "component",
+        timestamp,
+        format: FORMAT,
+        relative: true,
+        relativeThreshold: THRESHOLD,
+      },
+    });
+    flushSync();
+
+    const node = document.createElement("time");
+    document.body.appendChild(node);
+    const action = svelteTime(node, {
+      timestamp,
+      format: FORMAT,
+      relative: true,
+      relativeThreshold: THRESHOLD,
+    });
+
+    const componentNode = document.querySelector('[data-test="component"]');
+    assert(componentNode instanceof HTMLElement);
+
+    expect(componentNode.textContent).toEqual(expected);
+    expect(componentNode.title).toBeFalsy();
+    expect(node.textContent).toEqual(expected);
+    expect(node.title).toBeFalsy();
+
+    action?.destroy?.();
+    unmount(instance);
+  });
+
+  test("live: component, action, and attachment all flip together mid-tick", async () => {
+    const instance = mount(RelativeThreshold, { target: document.body });
+    flushSync();
+
+    const getElement = (selector: string) => {
+      const element = document.querySelector(selector);
+      assert(element instanceof HTMLElement);
+      return element;
+    };
+
+    const component = getElement('[data-test="component-threshold"]');
+    const action = getElement('[data-test="action-threshold"]');
+    const attachment = getElement('[data-test="attachment-threshold"]');
+
+    expect(/ago/.test(component.textContent ?? "")).toEqual(true);
+    expect(/ago/.test(action.textContent ?? "")).toEqual(true);
+    expect(/ago/.test(attachment.textContent ?? "")).toEqual(true);
+
+    vi.advanceTimersByTime(THRESHOLD * 1.5);
+    await tick();
+
+    expect(component.textContent).toEqual(action.textContent);
+    expect(action.textContent).toEqual(attachment.textContent);
+    expect(component.title).toBeFalsy();
+    expect(action.title).toBeFalsy();
+    expect(attachment.title).toBeFalsy();
+
     unmount(instance);
   });
 });

--- a/tests/examples/RelativeThreshold.svelte
+++ b/tests/examples/RelativeThreshold.svelte
@@ -1,0 +1,6 @@
+<script>
+  import Time from "svelte-time";
+</script>
+
+<!-- Shows "a minute ago", flips to "4:40 am" after 2 hours -->
+<Time relative live format="h:mm a" relativeThreshold={2 * 60 * 60 * 1000} />


### PR DESCRIPTION
Closes #11

Adds `relativeThreshold` (Time, svelteTime, time): once a `relative` timestamp's age meets or exceeds this value (ms), display switches to the absolute `format` instead of the relative string. Combined with `live`, this happens automatically as time passes, e.g. "a minute ago" flips to "4:40 am" after 2 hours with no remount required.

Default is `undefined` (disabled), fully backward compatible.

