### PR TITLE
feat: add relativeStyle prop for compact relative time

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,40 @@ This also works with the `svelteTime` action:
 ></time>
 ```
 
+### Compact relative time
+
+Set `relativeStyle` to `"micro"` to render relative time as a compact single unit (e.g. `"4d"`) instead of the humanized string (e.g. `"4 days ago"`) — handy for dense UIs like comment lists and notification feeds. Only applies when `relative` is `true`. Output uses fixed English unit letters (`y`/`mo`/`d`/`h`/`m`/`s`) regardless of the `locale` prop, since dayjs's `relativeTime` locale tables have no single-letter forms to draw from.
+
+<!-- render:RelativeStyleMicro -->
+
+```svelte
+<Time relative timestamp={pastDate} />
+<!-- Output: "4 days ago" -->
+
+<Time relative relativeStyle="micro" timestamp={pastDate} />
+<!-- Output: "4d" instead of "4 days ago" -->
+```
+
+This also works with the `svelteTime` action and the `time` attachment:
+
+```svelte
+<time
+  use:svelteTime={{
+    relative: true,
+    timestamp: pastDate,
+    relativeStyle: "micro",
+  }}
+></time>
+
+<time
+  {@attach time({
+    relative: true,
+    timestamp: pastDate,
+    relativeStyle: "micro",
+  })}
+></time>
+```
+
 ### `dayjs` export
 
 The `dayjs` library is exported from this package for your convenience.
@@ -385,14 +419,20 @@ To use a [custom locale](https://day.js.org/docs/en/i18n/changing-locale), impor
 <Time timestamp="2024-01-01" format="YYYY年M月D日(dddd)" locale="ja" />
 ```
 
-The `Locales` type is exported for TypeScript usage, along with `TimeProps` and
-`SvelteTimeOptions` for typing component wrappers and action options.
+The `Locales` type is exported for TypeScript usage, along with `TimeProps`,
+`SvelteTimeOptions`, and `RelativeStyle` for typing component wrappers and action options.
 
 ```typescript
-import type { Locales, TimeProps, SvelteTimeOptions } from "svelte-time";
+import type {
+  Locales,
+  TimeProps,
+  SvelteTimeOptions,
+  RelativeStyle,
+} from "svelte-time";
 
 const locale: Locales = "de";
 const localeStore = writable<Locales>("en");
+let style: RelativeStyle = $state("default");
 ```
 
 The `locale` prop also works with relative time.
@@ -607,6 +647,7 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 | format        | `string`                                              | `"MMM DD, YYYY"` (See [dayjs display format](https://day.js.org/docs/en/display/format)) |
 | relative      | `boolean`                                             | `false`                                                                                  |
 | withoutSuffix | `boolean`                                             | `false` (only applies when `relative` is `true`)                                         |
+| relativeStyle | `RelativeStyle` (`"default"` &#124; `"micro"`)        | `"default"` (only applies when `relative` is `true`)                                     |
 | live          | `boolean` &#124; `number`                             | `false`                                                                                  |
 | locale        | `Locales` (TypeScript) &#124; `string`                | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))    |
 | tz            | `string`                                              | `undefined` (See [tz prop](#tz-prop); requires the dayjs `utc`/`timezone` plugins)       |

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -29,6 +29,14 @@
     withoutSuffix = false,
 
     /**
+     * Presentation style for `relative` output. `"micro"` renders a
+     * compact single unit (e.g. "4d") instead of the humanized string
+     * (e.g. "4 days ago"). Only applies when `relative` is `true`.
+     * @type {import("./Time.svelte").RelativeStyle}
+     */
+    relativeStyle = "default",
+
+    /**
      * Set to `true` to update the relative time at 60 second interval.
      * Pass in a number (ms) to specify the interval length
      * @type {boolean | number}
@@ -59,6 +67,7 @@
 
   import { dayjs } from "./dayjs";
   import { toDatetime } from "./datetime";
+  import { microFormat } from "./micro";
   import { liveInterval, sharedNow } from "./ticker";
 
   const canTick = typeof document !== "undefined";
@@ -131,7 +140,9 @@
    */
   let formatted = $derived(
     relative
-      ? day.from(live !== false ? now : dayjs(), withoutSuffix)
+      ? relativeStyle === "micro"
+        ? microFormat(day.diff(live !== false ? now : dayjs()))
+        : day.from(live !== false ? now : dayjs(), withoutSuffix)
       : day.format(format),
   );
 

--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -5,6 +5,13 @@ import type { Locales } from "./locales";
 
 type RestProps = Omit<SvelteHTMLElements["time"], "children">;
 
+/**
+ * Presentation style for `relative` output. `"micro"` renders a
+ * compact single unit (e.g. "4d") instead of the humanized string
+ * (e.g. "4 days ago").
+ */
+export type RelativeStyle = "default" | "micro";
+
 export interface TimeProps extends RestProps {
   /**
    * Original timestamp
@@ -32,6 +39,16 @@ export interface TimeProps extends RestProps {
    * @default false
    */
   withoutSuffix?: boolean;
+
+  /**
+   * Presentation style for `relative` output. `"micro"` renders a
+   * compact single unit (e.g. "4d") instead of the humanized string
+   * (e.g. "4 days ago"). Only applies when `relative` is `true`. Output
+   * uses English unit letters regardless of the `locale` prop — see
+   * README.
+   * @default "default"
+   */
+  relativeStyle?: RelativeStyle;
 
   /**
    * Set to `true` to update the relative time at 60 second interval.

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -1,5 +1,6 @@
 import { dayjs } from "./dayjs";
 import { toDatetime } from "./datetime";
+import { microFormat } from "./micro";
 import { liveInterval, sharedNow } from "./ticker";
 
 const DEFAULT_INTERVAL = 60 * 1_000;
@@ -19,6 +20,7 @@ export function time(options = {}) {
     const format = options.format || "MMM DD, YYYY";
     const relative = options.relative === true;
     const withoutSuffix = options.withoutSuffix ?? false;
+    const relativeStyle = options.relativeStyle ?? "default";
     const live = options.live ?? false;
     const tz = options.tz;
     let locale = options.locale ?? "en";
@@ -77,7 +79,9 @@ export function time(options = {}) {
     if (datetime) node.setAttribute("datetime", datetime);
     else node.removeAttribute("datetime");
     node.textContent = relative
-      ? day.from(now, withoutSuffix)
+      ? relativeStyle === "micro"
+        ? microFormat(day.diff(now))
+        : day.from(now, withoutSuffix)
       : day.format(format);
   };
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,5 +3,5 @@ export { dayjs } from "./dayjs";
 export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";
 export type { Locales } from "./locales";
-export type { TimeProps } from "./Time.svelte";
+export type { TimeProps, RelativeStyle } from "./Time.svelte";
 export type { SvelteTimeOptions } from "./svelte-time.svelte";

--- a/src/micro.d.ts
+++ b/src/micro.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Compact single-unit relative time, e.g. "4d", "2h", "5y", "1m", "6s".
+ * Largest applicable unit, floor-rounded, magnitude only (no sign/suffix —
+ * pair with a "+"/"-" prefix yourself if you need direction).
+ */
+export declare function microFormat(ms: number): string;

--- a/src/micro.js
+++ b/src/micro.js
@@ -1,0 +1,23 @@
+const UNITS = [
+  ["y", 365 * 86_400_000],
+  ["mo", 30 * 86_400_000],
+  ["d", 86_400_000],
+  ["h", 3_600_000],
+  ["m", 60_000],
+  ["s", 1_000],
+];
+
+/**
+ * Compact single-unit relative time, e.g. "4d", "2h", "5y", "1m", "6s".
+ * Largest applicable unit, floor-rounded, magnitude only (no sign/suffix —
+ * pair with a "+"/"-" prefix yourself if you need direction).
+ * @param {number} ms absolute or signed duration in milliseconds
+ * @returns {string}
+ */
+export function microFormat(ms) {
+  const abs = Math.abs(ms);
+  for (const [unit, unitMs] of UNITS) {
+    if (abs >= unitMs) return `${Math.floor(abs / unitMs)}${unit}`;
+  }
+  return "0s";
+}

--- a/src/svelte-time.svelte.d.ts
+++ b/src/svelte-time.svelte.d.ts
@@ -7,6 +7,7 @@ export interface SvelteTimeOptions extends Pick<
   | "format"
   | "relative"
   | "withoutSuffix"
+  | "relativeStyle"
   | "live"
   | "title"
   | "locale"

--- a/src/svelte-time.svelte.js
+++ b/src/svelte-time.svelte.js
@@ -1,5 +1,6 @@
 import { dayjs } from "./dayjs";
 import { toDatetime } from "./datetime";
+import { microFormat } from "./micro";
 
 /**
  * @typedef {import("./svelte-time.svelte").SvelteTimeOptions} SvelteTimeOptions
@@ -20,6 +21,7 @@ export const svelteTime = (node, options = {}) => {
     const format = options.format || "MMM DD, YYYY";
     const relative = options.relative === true;
     const withoutSuffix = options.withoutSuffix ?? false;
+    const relativeStyle = options.relativeStyle ?? "default";
     const live = options.live ?? false;
     const tz = options.tz;
     let locale = options.locale ?? "en";
@@ -53,8 +55,11 @@ export const svelteTime = (node, options = {}) => {
     let formatted = getDay().format(format);
 
     if (relative) {
-      // Use dayjs's built-in withoutSuffix parameter (locale-aware)
-      formatted = getDay().from(dayjs(), withoutSuffix);
+      formatted =
+        relativeStyle === "micro"
+          ? microFormat(getDay().diff(dayjs()))
+          : // Use dayjs's built-in withoutSuffix parameter (locale-aware)
+            getDay().from(dayjs(), withoutSuffix);
 
       if ("title" in options) {
         if (options.title !== undefined) {
@@ -67,7 +72,10 @@ export const svelteTime = (node, options = {}) => {
       if (live !== false) {
         interval = setInterval(
           () => {
-            node.textContent = getDay().from(dayjs(), withoutSuffix);
+            node.textContent =
+              relativeStyle === "micro"
+                ? microFormat(getDay().diff(dayjs()))
+                : getDay().from(dayjs(), withoutSuffix);
           },
           Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
         );

--- a/tests/RelativeStyle.test.svelte
+++ b/tests/RelativeStyle.test.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import Time from "svelte-time";
+</script>
+
+<!-- Compact "micro" style -->
+<Time
+  data-test="micro"
+  relative
+  relativeStyle="micro"
+  timestamp="2023-12-28T00:00:00.000Z"
+  format="MMM DD, YYYY"
+/>
+
+<!-- relativeStyle="micro" without relative: no-op, renders absolute format -->
+<Time
+  data-test="micro-without-relative"
+  relativeStyle="micro"
+  timestamp="2023-12-28T00:00:00.000Z"
+  format="MMM DD, YYYY"
+/>
+
+<!-- relativeStyle="default" (explicit) -->
+<Time
+  data-test="default-style"
+  relative
+  relativeStyle="default"
+  timestamp="2023-12-28T00:00:00.000Z"
+  format="MMM DD, YYYY"
+/>
+
+<!-- relativeStyle omitted -->
+<Time data-test="omitted-style" relative timestamp="2023-12-28T00:00:00.000Z" />
+
+<!-- relativeStyle={undefined} -->
+<Time
+  data-test="undefined-style"
+  relative
+  relativeStyle={undefined}
+  timestamp="2023-12-28T00:00:00.000Z"
+/>
+
+<!-- relativeStyle is an unrecognized string -->
+<Time
+  data-test="unknown-style"
+  relative
+  relativeStyle="bogus"
+  timestamp="2023-12-28T00:00:00.000Z"
+/>

--- a/tests/RelativeStyle.test.ts
+++ b/tests/RelativeStyle.test.ts
@@ -1,0 +1,100 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import { microFormat } from "../src/micro.js";
+import RelativeStyleTest from "./RelativeStyle.test.svelte";
+
+describe("microFormat", () => {
+  test.each([
+    [0, "0s"],
+    [59_000, "59s"],
+    [60_000, "1m"],
+    [3_599_000, "59m"],
+    [3_600_000, "1h"],
+    [86_400_000 - 1, "23h"],
+    [86_400_000, "1d"],
+    [30 * 86_400_000 - 1, "29d"],
+    [30 * 86_400_000, "1mo"],
+    [365 * 86_400_000 - 1, "12mo"],
+    [365 * 86_400_000, "1y"],
+  ])("microFormat(%i) === %s", (ms, expected) => {
+    expect(microFormat(ms)).toEqual(expected);
+  });
+
+  test("ignores sign — magnitude only", () => {
+    expect(microFormat(-60_000)).toEqual(microFormat(60_000));
+  });
+});
+
+describe("Time component with relativeStyle prop", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test('relativeStyle="micro" renders a compact single unit', () => {
+    const target = document.body;
+    instance = mount(RelativeStyleTest, { target });
+    flushSync();
+
+    const element = getElement('[data-test="micro"]');
+    expect(element.innerHTML).toEqual("4d");
+    // title is unaffected by relativeStyle — still the full absolute format
+    expect(element.title).toEqual(
+      dayjs("2023-12-28T00:00:00.000Z").format("MMM DD, YYYY"),
+    );
+  });
+
+  test('relativeStyle="micro" is a no-op without relative', () => {
+    const target = document.body;
+    instance = mount(RelativeStyleTest, { target });
+    flushSync();
+
+    const withMicro = getElement('[data-test="micro-without-relative"]');
+    expect(withMicro.innerHTML).toEqual(
+      dayjs("2023-12-28T00:00:00.000Z").format("MMM DD, YYYY"),
+    );
+    expect(withMicro.title).toBeFalsy();
+  });
+
+  test('relativeStyle="default" matches the omitted-prop behavior', () => {
+    const target = document.body;
+    instance = mount(RelativeStyleTest, { target });
+    flushSync();
+
+    const defaultStyle = getElement('[data-test="default-style"]');
+    const omittedStyle = getElement('[data-test="omitted-style"]');
+    expect(defaultStyle.innerHTML).toEqual(omittedStyle.innerHTML);
+    expect(defaultStyle.innerHTML).toEqual(
+      dayjs("2023-12-28T00:00:00.000Z").from(dayjs(FIXED_DATE)),
+    );
+  });
+
+  test("unrecognized or undefined relativeStyle falls back to default", () => {
+    const target = document.body;
+    instance = mount(RelativeStyleTest, { target });
+    flushSync();
+
+    const omittedStyle = getElement('[data-test="omitted-style"]');
+    const undefinedStyle = getElement('[data-test="undefined-style"]');
+    const unknownStyle = getElement('[data-test="unknown-style"]');
+
+    expect(undefinedStyle.innerHTML).toEqual(omittedStyle.innerHTML);
+    expect(unknownStyle.innerHTML).toEqual(omittedStyle.innerHTML);
+  });
+});

--- a/tests/SvelteTimeParity.test.ts
+++ b/tests/SvelteTimeParity.test.ts
@@ -7,6 +7,51 @@ import Time, { svelteTime, time } from "svelte-time";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+describe('component/action/attachment parity for relativeStyle="micro"', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("component, action, and attachment render the same micro output", () => {
+    const options = {
+      relative: true,
+      relativeStyle: "micro",
+      timestamp: "2023-12-28T00:00:00.000Z",
+    } as const;
+
+    const instance = mount(Time, {
+      target: document.body,
+      props: { "data-test": "component", ...options },
+    });
+    flushSync();
+
+    const actionNode = document.createElement("time");
+    document.body.appendChild(actionNode);
+    const action = svelteTime(actionNode, options);
+
+    const attachmentNode = document.createElement("time");
+    document.body.appendChild(attachmentNode);
+    time(options)(attachmentNode);
+
+    const componentText = document
+      .querySelector('[data-test="component"]')
+      ?.textContent?.trim();
+
+    expect(componentText).toEqual("4d");
+    expect(actionNode.textContent?.trim()).toEqual("4d");
+    expect(attachmentNode.textContent?.trim()).toEqual("4d");
+
+    action?.destroy?.();
+    unmount(instance);
+  });
+});
+
 describe("component/action parity for edge-case timestamps", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/tests/SvelteTimeReactive.test.svelte
+++ b/tests/SvelteTimeReactive.test.svelte
@@ -50,3 +50,11 @@
   {live}
 />
 <button data-test="btn-live" onclick={toggleLive}>Toggle live</button>
+
+<Time
+  data-test="reactive-live-micro"
+  timestamp={new Date().toISOString()}
+  relative
+  relativeStyle="micro"
+  live={1000}
+/>

--- a/tests/SvelteTimeReactive.test.ts
+++ b/tests/SvelteTimeReactive.test.ts
@@ -133,4 +133,21 @@ describe("svelte-time-reactive", () => {
     await tick();
     expect(element.innerHTML).toEqual("2 minutes ago");
   });
+
+  test('relativeStyle="micro" + live ticks and changes tier (59s -> 1m)', async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeReactive, { target });
+    flushSync();
+
+    const element = getElement('[data-test="reactive-live-micro"]');
+    expect(element.innerHTML).toEqual("0s");
+
+    vi.advanceTimersByTime(59_000);
+    await tick();
+    expect(element.innerHTML).toEqual("59s");
+
+    vi.advanceTimersByTime(1_000);
+    await tick();
+    expect(element.innerHTML).toEqual("1m");
+  });
 });

--- a/tests/examples/RelativeStyleMicro.svelte
+++ b/tests/examples/RelativeStyleMicro.svelte
@@ -1,0 +1,13 @@
+<script>
+  import Time, { dayjs } from "svelte-time";
+
+  const pastDate = dayjs().subtract(4, "days").toISOString();
+</script>
+
+<div>
+  <Time relative timestamp={pastDate} />
+</div>
+
+<div>
+  <Time relative relativeStyle="micro" timestamp={pastDate} />
+</div>


### PR DESCRIPTION
## Summary
- Adds a `relativeStyle` prop (`Time`, `svelteTime`, `time`), default `"default"`, with a `"micro"` option that renders relative time as a compact single unit — `"4d"` instead of `"4 days ago"` — for dense UIs like comment lists and notification feeds.
- Chosen as an enum rather than a boolean so future relative presentation styles can be added as new union members instead of a second, mutually-exclusive boolean prop.
- Only applies when `relative` is `true`; `"micro"` output uses fixed English unit letters (`y`/`mo`/`d`/`h`/`m`/`s`) regardless of `locale`, since dayjs's `relativeTime` locale tables have no single-letter forms to draw from. Unrecognized values fall back to `"default"` rather than throwing, for forward compatibility.

Closes #46.

## Test plan
- [x] `bunx vitest run` passes in both `client` and `ssr` projects (100 tests)
- [x] `tests/SvelteTimeParity.test.ts` covers `relativeStyle` across component, action, and attachment
- [x] `bun run package` output includes the `RelativeStyle` type export
- [x] `bun run build` (demo site) succeeds and renders the new README example