### PR TITLE
test: add regression test for svelteTime action $state.raw reassignment (#62)

### DIFF
--- a/tests/SvelteTimeAction.test.ts
+++ b/tests/SvelteTimeAction.test.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { flushSync, mount, unmount } from "svelte";
 import { svelteTime } from "../src/svelte-time.svelte.js";
 import SvelteTimeAction from "./examples/SvelteTimeAction.svelte";
+import SvelteTimeActionStateRaw from "./examples/SvelteTimeActionStateRaw.svelte";
 
 describe("svelte-time-action", () => {
   let instance: null | ReturnType<typeof mount> = null;
@@ -128,5 +129,24 @@ describe("svelte-time-action", () => {
     );
     expect(timeElement.innerText).toEqual(secondUpdatedFormattedDate);
     expect(timeElement.getAttribute("datetime")).toEqual("2021-02-04");
+  });
+
+  // Regression test for https://github.com/metonym/svelte-time/issues/62
+  test("updates when the whole options object passed via $state.raw is reassigned", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeActionStateRaw, { target });
+    flushSync();
+
+    const timeElement = getElement("time");
+    const format = "dddd @ h:mm A · MMMM D, YYYY";
+    expect(timeElement.innerText).toEqual(dayjs("2021-02-02").format(format));
+    expect(timeElement.getAttribute("datetime")).toEqual("2021-02-02");
+
+    const button = getElement("button");
+    button.click();
+    flushSync();
+
+    expect(timeElement.innerText).toEqual(dayjs("2025-04-02").format(format));
+    expect(timeElement.getAttribute("datetime")).toEqual("2025-04-02");
   });
 });

--- a/tests/examples/SvelteTimeActionStateRaw.svelte
+++ b/tests/examples/SvelteTimeActionStateRaw.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { svelteTime } from "svelte-time";
+
+  let data = $state.raw({
+    timestamp: "2021-02-02",
+    format: "dddd @ h:mm A · MMMM D, YYYY",
+  });
+
+  function updateData() {
+    data = {
+      timestamp: "2025-04-02",
+      format: "dddd @ h:mm A · MMMM D, YYYY",
+    };
+  }
+</script>
+
+<button onclick={updateData}>Update</button>
+
+<div>
+  <time use:svelteTime={data}></time>
+</div>


### PR DESCRIPTION
Closes #62

- Adds a regression test reproducing the exact repro from #62: a `use:svelteTime={data}` action where `data` is declared with `$state.raw` and reassigned wholesale (not mutated in place).
- Confirms the action already updates correctly against the current `svelteTime` implementation — the v2.0.2 reactivity fix ("restore reactivity for `Time` component and `svelteTime` action") covers this case.
- No production code changes; this is a verify-and-close item per the issue triage.