### PR TITLE
feat: add Duration component, svelteDuration action, and duration attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use [svelte-time@1.0.0](https://github.com/metonym/svelte-time/tree/v1.0.0) for 
 
 ## About
 
-`svelte-time` is a Svelte component and action to make a timestamp human-readable while encoding the machine-parseable value in the semantic `time` element.
+`svelte-time` is a Svelte component and action library for formatting timestamps and durations, encoding the machine-parseable value in the semantic `time` element.
 
 Under the hood, it uses [day.js](https://github.com/iamkun/dayjs), a lightweight date-time library.
 
@@ -421,7 +421,7 @@ This also works with the `svelteTime` action and the `time` attachment:
 
 The `dayjs` library is exported from this package for your convenience.
 
-**Note**: the exported `dayjs` function already extends the [relativeTime plugin](https://day.js.org/docs/en/plugin/relative-time).
+**Note**: the exported `dayjs` function already extends the [relativeTime plugin](https://day.js.org/docs/en/plugin/relative-time) and the [duration plugin](https://day.js.org/docs/en/durations/durations).
 
 <!-- render:DayjsExport -->
 
@@ -706,9 +706,124 @@ dayjs().local().format("z"); // EST
 dayjs().local().format("zzz"); // Eastern Standard Time
 ```
 
+## Duration
+
+`svelte-time` also ships a `Duration` component (plus a `svelteDuration` action and a `duration` attachment) for formatting a span of time — e.g. a video length, a countdown, or a stopwatch — as opposed to `Time`, which formats a point in time.
+
+### `Duration` component
+
+`value` accepts a plain number (paired with `unit`), an ISO 8601 duration string (e.g. `"PT1H30M"`), a plain object of unit fields, or a dayjs `Duration` instance. The default `format` is `"HH:mm:ss"`.
+
+<!-- render:DurationBasic -->
+
+```svelte
+<script>
+  import { Duration } from "svelte-time";
+</script>
+
+<!-- Default format: "HH:mm:ss" -->
+<Duration value={3661000} />
+<!-- Output: "01:01:01" -->
+
+<!-- unit converts a plain number before formatting -->
+<Duration value={90} unit="seconds" format="mm:ss" />
+<!-- Output: "01:30" -->
+```
+
+Unlike dayjs's own `duration.format()`, which drops any magnitude above the units present in the template, `format` rolls that magnitude into the largest unit that _is_ present — handy for players/timers that hide hours until they're needed:
+
+```svelte
+<Duration value={5400000} format="mm:ss" />
+<!-- Output: "90:00", not "30:00" -->
+```
+
+### Humanize
+
+Set `humanize` to `true` to render the duration as a natural-language string (using dayjs's `duration.humanize()`) instead of `format`. Set `withSuffix` to `true` to include a relative suffix (e.g. "in an hour" / "an hour ago") — off by default, since a plain span (a video length, a meeting duration) isn't inherently relative to now.
+
+<!-- render:DurationHumanize -->
+
+```svelte
+<script>
+  import { Duration } from "svelte-time";
+</script>
+
+<Duration value={3600000} humanize />
+<!-- Output: "an hour" -->
+
+<Duration value={3600000} humanize withSuffix />
+<!-- Output: "in an hour" -->
+```
+
+### Locale
+
+Use the `locale` prop to format durations in different languages. Make sure to import the locale from `dayjs` first.
+
+<!-- render:DurationLocale -->
+
+```svelte
+<script>
+  import "dayjs/locale/de";
+  import { Duration } from "svelte-time";
+</script>
+
+<Duration value={3600000} humanize locale="de" />
+<!-- Output: "eine Stunde" -->
+```
+
+### Live elapsed duration (stopwatch)
+
+Pass a `since` timestamp instead of `value` to display the elapsed time since that instant — `since` and `live` turn `Duration` into a stopwatch, ticking at an adaptive interval (the same shared clock the `Time` component's `relative live` mode uses). `value`/`unit` are ignored when `since` is set.
+
+<!-- render:DurationSince -->
+
+```svelte
+<script>
+  import { Duration } from "svelte-time";
+
+  const since = new Date().toISOString();
+</script>
+
+<Duration {since} live format="HH:mm:ss" />
+```
+
+Pass a number to `live` for a fixed interval instead of the adaptive default:
+
+```svelte
+<Duration since={startedAt} live={1000} format="HH:mm:ss" />
+```
+
+### `svelteDuration` action
+
+An alternative to the `Duration` component is the `svelteDuration` action, for formatting a duration on a raw HTML element. The API is the same as the `Duration` component.
+
+<!-- render:SvelteDurationAction -->
+
+```svelte
+<script>
+  import { svelteDuration } from "svelte-time";
+</script>
+
+<time use:svelteDuration={{ value: 3661000 }}></time>
+```
+
+### `duration` attachment
+
+The `duration` attachment is the [attachment](#time-attachment) equivalent of `svelteDuration`, with the same fully-reactive behavior as the `time` attachment.
+
+<!-- render:DurationAttachmentExample -->
+
+```svelte
+<script>
+  import { duration } from "svelte-time";
+</script>
+
+<time {@attach duration({ value: 3661000 })}></time>
+```
+
 ## API
 
-### Props
+### `Time` component props
 
 | Name              | Type                                                  | Default value              | Description                                                                                                                                                                       |
 | :---------------- | :---------------------------------------------------- | :------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -736,6 +851,20 @@ Both the `svelteTime` action and the `time` attachment accept the same options a
 ### Accessibility
 
 The machine-readable `datetime` attribute is the accessible, parseable channel; the `title` tooltip isn't reachable via touch or keyboard, so don't rely on it to convey essential information: show the absolute date in text when it matters. Live text updates are deliberately not announced (`aria-live` is intentionally omitted): minute-by-minute announcements would be hostile to screen-reader users.
+
+### `Duration` component props
+
+| Name       | Type                                                                                                                                        | Default value                                                                         |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------ |
+| value      | `number` &#124; `string` &#124; `object` &#124; `Duration`                                                                                  | `0` (ignored when `since` is set)                                                     |
+| unit       | `"milliseconds"` &#124; `"seconds"` &#124; `"minutes"` &#124; `"hours"` &#124; `"days"` &#124; `"weeks"` &#124; `"months"` &#124; `"years"` | `"milliseconds"` (only applies when `value` is a plain number)                        |
+| since      | `string` &#124; `number` &#124; `Date` &#124; `Dayjs`                                                                                       | `undefined` (see [live elapsed duration](#live-elapsed-duration-stopwatch))           |
+| format     | `string`                                                                                                                                    | `"HH:mm:ss"`                                                                          |
+| humanize   | `boolean`                                                                                                                                   | `false`                                                                               |
+| withSuffix | `boolean`                                                                                                                                   | `false` (only applies when `humanize` is `true`)                                      |
+| locale     | `Locales` (TypeScript) &#124; `string`                                                                                                      | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale)) |
+| live       | `boolean` &#124; `number`                                                                                                                   | `false` (only applies when `since` is set)                                            |
+| children   | `Snippet<[string]>`                                                                                                                         | `undefined`                                                                           |
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-time",
   "version": "2.1.0",
   "license": "MIT",
-  "description": "Svelte component and action to format a timestamp using day.js",
+  "description": "Svelte component and action library for formatting timestamps and durations using day.js",
   "author": "Eric Liu (https://github.com/metonym)",
   "type": "module",
   "svelte": "./src/index.js",
@@ -47,6 +47,9 @@
     "time formatter",
     "timestamp",
     "relative",
-    "ago"
+    "ago",
+    "duration",
+    "timer",
+    "stopwatch"
   ]
 }

--- a/src/Duration.svelte
+++ b/src/Duration.svelte
@@ -1,0 +1,141 @@
+<script>
+  const {
+    /**
+     * Duration value. Accepts anything dayjs's `duration()` accepts: a
+     * number (paired with `unit`), an ISO 8601 duration string (e.g.
+     * "PT1H30M"), a plain object of unit fields, or a dayjs `Duration`
+     * instance. Ignored when `since` is provided.
+     * @type {number | string | object | import("./duration-format").DayjsDuration}
+     */
+    value = 0,
+
+    /**
+     * Unit for the duration value. Only applies when `value` is a plain number.
+     * @type {import("./duration-format").DurationUnit}
+     */
+    unit = "milliseconds",
+
+    /**
+     * Start instant to count elapsed time from (e.g. a stopwatch/timer).
+     * When provided, `value` and `unit` are ignored and the displayed
+     * duration is `now - since`.
+     * @type {import("dayjs").ConfigType}
+     */
+    since = undefined,
+
+    /**
+     * Format for display, using dayjs's duration `format()` tokens
+     * (e.g. "HH:mm:ss"). Ignored when `humanize` is `true`.
+     * @type {string}
+     */
+    format = "HH:mm:ss",
+
+    /**
+     * Set to `true` to display the duration in a human-readable format
+     * (e.g. "an hour", "2 minutes") instead of `format`.
+     * @type {boolean}
+     */
+    humanize = false,
+
+    /**
+     * Set to `true` to include a relative suffix in humanized output
+     * (e.g. "in an hour" / "an hour ago"). Only applies when `humanize`
+     * is `true`.
+     * @type {boolean}
+     */
+    withSuffix = false,
+
+    /**
+     * The locale to use for formatting
+     * @type {import("./locales").Locales}
+     */
+    locale = "en",
+
+    /**
+     * Set to `true` to update the elapsed duration at an adaptive
+     * interval. Pass a number (ms) to specify a fixed interval. Only
+     * applies when `since` is provided.
+     * @type {boolean | number}
+     */
+    live = false,
+
+    /**
+     * Snippet rendered inside the `time` element instead of the plain
+     * formatted string. Receives the formatted value as its argument.
+     * @type {import("svelte").Snippet<[string]> | undefined}
+     */
+    children,
+    ...rest
+  } = $props();
+
+  import { dayjs } from "./dayjs";
+  import { formatDuration } from "./duration-format";
+  import { liveInterval, sharedNow } from "./ticker";
+
+  const canTick = typeof document !== "undefined";
+
+  // Tier for adaptive `live === true` scheduling. See Time.svelte for
+  // why this is seeded via `$state` + an effect rather than derived
+  // directly from `now` (avoiding a `now` -> interval -> `now` cycle).
+  let interval = $state(
+    liveInterval(since === undefined ? 0 : dayjs(since).diff(dayjs())),
+  );
+
+  $effect(() => {
+    if (since !== undefined && live === true) {
+      const next = liveInterval(dayjs(since).diff(now));
+      if (next !== interval) interval = next;
+    }
+  });
+
+  const effectiveInterval = $derived(
+    typeof live === "number" ? Math.abs(live) : interval,
+  );
+
+  const now = $derived(
+    since !== undefined && live !== false && canTick
+      ? sharedNow(effectiveInterval)
+      : dayjs(),
+  );
+
+  /**
+   * Formatted duration and its ISO 8601 `datetime` value.
+   * @type {{ formatted: string, datetime: string }}
+   */
+  const result = $derived.by(() => {
+    if (since !== undefined) {
+      return formatDuration({
+        value: now.diff(dayjs(since)),
+        unit: "milliseconds",
+        format,
+        humanize,
+        withSuffix,
+        locale,
+      });
+    }
+    return formatDuration({
+      value,
+      unit,
+      format,
+      humanize,
+      withSuffix,
+      locale,
+    });
+  });
+</script>
+
+{#if children}
+  <time
+    datetime={result.datetime}
+    {...rest}
+  >
+    {@render children(result.formatted)}
+  </time>
+{:else}
+  <time
+    datetime={result.datetime}
+    {...rest}
+  >
+    {result.formatted}
+  </time>
+{/if}

--- a/src/Duration.svelte.d.ts
+++ b/src/Duration.svelte.d.ts
@@ -1,0 +1,80 @@
+import type { ConfigType } from "dayjs";
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { DayjsDuration, DurationUnit } from "./duration-format";
+import type { Locales } from "./locales";
+
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
+
+export interface DurationProps extends RestProps {
+  /**
+   * Duration value. Accepts anything dayjs's `duration()` accepts: a
+   * number (paired with `unit`), an ISO 8601 duration string (e.g.
+   * "PT1H30M"), a plain object of unit fields, or a dayjs `Duration`
+   * instance. Ignored when `since` is provided.
+   * @default 0
+   */
+  value?: number | string | object | DayjsDuration;
+
+  /**
+   * Unit for the duration value. Only applies when `value` is a plain number.
+   * @default "milliseconds"
+   */
+  unit?: DurationUnit;
+
+  /**
+   * Start instant to count elapsed time from (e.g. a stopwatch/timer).
+   * When provided, `value` and `unit` are ignored and the displayed
+   * duration is `now - since`.
+   * @default undefined
+   */
+  since?: ConfigType;
+
+  /**
+   * Format for display, using dayjs's duration `format()` tokens
+   * (e.g. "HH:mm:ss"). Ignored when `humanize` is `true`.
+   * @default "HH:mm:ss"
+   */
+  format?: string;
+
+  /**
+   * Set to `true` to display the duration in a human-readable format
+   * (e.g. "an hour", "2 minutes") instead of `format`.
+   * @default false
+   */
+  humanize?: boolean;
+
+  /**
+   * Set to `true` to include a relative suffix in humanized output
+   * (e.g. "in an hour" / "an hour ago"). Only applies when `humanize`
+   * is `true`.
+   * @default false
+   */
+  withSuffix?: boolean;
+
+  /**
+   * The locale to use for formatting
+   * @default "en"
+   */
+  locale?: Locales;
+
+  /**
+   * Set to `true` to update the elapsed duration at an adaptive
+   * interval. Pass a number (ms) to specify a fixed interval. Only
+   * applies when `since` is provided.
+   * @default false
+   */
+  live?: boolean | number;
+
+  /**
+   * Snippet rendered inside the `time` element instead of the plain
+   * formatted string. Receives the formatted value as its argument.
+   */
+  children?: Snippet<[string]>;
+
+  [key: `data-${string}`]: unknown;
+}
+
+declare const Duration: Component<DurationProps>;
+
+export default Duration;

--- a/src/attachment.d.ts
+++ b/src/attachment.d.ts
@@ -1,6 +1,11 @@
 import type { Attachment } from "svelte/attachments";
+import type { SvelteDurationOptions } from "./svelte-duration.svelte";
 import type { SvelteTimeOptions } from "./svelte-time.svelte";
 
 export function time(
   options?: Partial<SvelteTimeOptions>,
+): Attachment<HTMLElement>;
+
+export function duration(
+  options?: Partial<SvelteDurationOptions>,
 ): Attachment<HTMLElement>;

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -1,5 +1,6 @@
 import { toDatetime } from "./datetime";
 import { dayjs } from "./dayjs";
+import { formatDuration } from "./duration-format";
 import { microFormat } from "./micro";
 import { liveInterval, sharedNow } from "./ticker";
 
@@ -88,5 +89,62 @@ export function time(options = {}) {
         ? microFormat(day.diff(now))
         : day.from(now, withoutSuffix)
       : day.format(format);
+  };
+}
+
+/**
+ * Attachment version of `svelteDuration`. Options are reactive: the
+ * attachment re-runs when any reactive value used to build `options`
+ * changes, and `since` + `live` mode subscribes to the shared ticker.
+ *
+ * @param {Partial<import("./svelte-duration.svelte").SvelteDurationOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach duration({ since: startedAt, live: true })}></time>
+ */
+export function duration(options = {}) {
+  return (node) => {
+    const value = options.value ?? 0;
+    const unit = options.unit ?? "milliseconds";
+    const since = options.since;
+    const format = options.format ?? "HH:mm:ss";
+    const humanize = options.humanize ?? false;
+    const withSuffix = options.withSuffix ?? false;
+    const locale = options.locale ?? "en";
+    const live = options.live ?? false;
+
+    let result;
+
+    if (since === undefined) {
+      result = formatDuration({
+        value,
+        unit,
+        format,
+        humanize,
+        withSuffix,
+        locale,
+      });
+    } else {
+      let now = dayjs();
+      if (live !== false) {
+        // Reading sharedNow subscribes this attachment to the shared
+        // clock; each tick re-runs the whole attachment.
+        const interval =
+          typeof live === "number"
+            ? Math.abs(live)
+            : liveInterval(dayjs(since).diff(dayjs()));
+        now = sharedNow(interval);
+      }
+      result = formatDuration({
+        value: now.diff(dayjs(since)),
+        unit: "milliseconds",
+        format,
+        humanize,
+        withSuffix,
+        locale,
+      });
+    }
+
+    node.setAttribute("datetime", result.datetime);
+    node.textContent = result.formatted;
   };
 }

--- a/src/dayjs.d.ts
+++ b/src/dayjs.d.ts
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
 import "dayjs/plugin/relativeTime.js";
+import "dayjs/plugin/duration.js";
 
 export { dayjs };

--- a/src/dayjs.js
+++ b/src/dayjs.js
@@ -1,6 +1,8 @@
 import dayjs from "dayjs";
+import duration from "dayjs/plugin/duration.js";
 import relativeTime from "dayjs/plugin/relativeTime.js";
 
 dayjs.extend(relativeTime);
+dayjs.extend(duration);
 
 export { dayjs };

--- a/src/duration-format.d.ts
+++ b/src/duration-format.d.ts
@@ -1,0 +1,32 @@
+import type { Locales } from "./locales";
+
+/** A dayjs `Duration` instance (from the `duration` plugin). */
+export type DayjsDuration = ReturnType<typeof import("dayjs")["duration"]>;
+
+export type DurationUnit =
+  | "milliseconds"
+  | "seconds"
+  | "minutes"
+  | "hours"
+  | "days"
+  | "weeks"
+  | "months"
+  | "years";
+
+export interface FormatDurationOptions {
+  value?: number | string | object | DayjsDuration;
+  unit?: DurationUnit;
+  format?: string;
+  humanize?: boolean;
+  withSuffix?: boolean;
+  locale?: Locales | string;
+}
+
+/**
+ * Normalize `value` into a dayjs `Duration` and render it, shared by the
+ * `Duration` component, `svelteDuration` action, and `duration` attachment.
+ */
+export declare function formatDuration(options?: FormatDurationOptions): {
+  formatted: string;
+  datetime: string;
+};

--- a/src/duration-format.js
+++ b/src/duration-format.js
@@ -1,0 +1,92 @@
+import { dayjs } from "./dayjs";
+
+const TOKEN_REGEX = /\[([^\]]+)]|Y+|M+|D+|H+|m+|s+|S+/g;
+
+/** Largest-to-smallest so excess magnitude rolls into the largest
+ * token present in the template instead of being dropped. */
+const HIERARCHY = ["Y", "M", "D", "H", "m", "s", "S"];
+
+/** Matches dayjs duration's own approximation constants (365d/year, ~30.4d/month). */
+const UNIT_MS = {
+  Y: 31536000000,
+  M: 2628000000,
+  D: 86400000,
+  H: 3600000,
+  m: 60000,
+  s: 1000,
+  S: 1,
+};
+
+/**
+ * Render `totalMs` against `template`. Unlike dayjs's own decomposed
+ * `duration.format()` (which drops any magnitude above the units present
+ * in the template — e.g. `format="mm:ss"` on 90 minutes renders "30:00"),
+ * this rolls all magnitude larger than the largest present token into
+ * that token — the same example renders "90:00". Supports the `[...]`
+ * literal-text escape.
+ * @param {number} totalMs
+ * @param {string} template
+ * @returns {string}
+ */
+function renderTemplate(totalMs, template) {
+  const tokens = template.match(TOKEN_REGEX) || [];
+  const presentTypes = new Set(
+    tokens.filter((token) => token[0] !== "[").map((token) => token[0]),
+  );
+
+  const negative = totalMs < 0;
+  let remaining = Math.abs(totalMs);
+  /** @type {Record<string, number>} */
+  const values = {};
+
+  for (const type of HIERARCHY) {
+    if (!presentTypes.has(type)) continue;
+    const unitMs = UNIT_MS[type];
+    values[type] = Math.floor(remaining / unitMs);
+    remaining -= values[type] * unitMs;
+  }
+
+  const rendered = template.replace(TOKEN_REGEX, (match, bracketed) => {
+    if (bracketed !== undefined) return bracketed;
+    return String(values[match[0]]).padStart(match.length, "0");
+  });
+
+  return negative && presentTypes.size > 0 ? `-${rendered}` : rendered;
+}
+
+/**
+ * Normalize `value` into a dayjs `Duration` and render it, shared by the
+ * `Duration` component, `svelteDuration` action, and `duration` attachment
+ * so the formatting logic lives in exactly one place.
+ * @param {object} options
+ * @param {number | string | object | import("dayjs").Duration} [options.value]
+ * @param {"milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"} [options.unit]
+ * @param {string} [options.format]
+ * @param {boolean} [options.humanize]
+ * @param {boolean} [options.withSuffix]
+ * @param {import("./locales").Locales | string} [options.locale]
+ * @returns {{ formatted: string, datetime: string }}
+ */
+export function formatDuration({
+  value = 0,
+  unit = "milliseconds",
+  format = "HH:mm:ss",
+  humanize = false,
+  withSuffix = false,
+  locale = "en",
+} = {}) {
+  const base = dayjs.isDuration(value)
+    ? value
+    : typeof value === "number"
+      ? dayjs.duration(value, unit)
+      : dayjs.duration(value);
+
+  const duration = base.locale(locale);
+
+  return {
+    formatted: humanize
+      ? duration.humanize(withSuffix)
+      : renderTemplate(duration.asMilliseconds(), format),
+    datetime: duration.toISOString(),
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,11 @@
-export { time } from "./attachment";
+export { duration, time } from "./attachment";
+export type { DurationProps } from "./Duration.svelte";
+export { default as Duration } from "./Duration.svelte";
 export { dayjs } from "./dayjs";
+export type { DayjsDuration, DurationUnit } from "./duration-format";
 export type { Locales } from "./locales";
+export type { SvelteDurationOptions } from "./svelte-duration.svelte";
+export { svelteDuration } from "./svelte-duration.svelte";
 export type { SvelteTimeOptions } from "./svelte-time.svelte";
 export { svelteTime } from "./svelte-time.svelte";
 export type { RelativeStyle, TimeProps } from "./Time.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-export { time } from "./attachment";
+export { duration, time } from "./attachment";
+export { default as Duration } from "./Duration.svelte";
 export { dayjs } from "./dayjs";
+export { svelteDuration } from "./svelte-duration.svelte";
 export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";

--- a/src/svelte-duration.svelte.d.ts
+++ b/src/svelte-duration.svelte.d.ts
@@ -1,0 +1,20 @@
+import type { Action } from "svelte/action";
+import type { DurationProps } from "./Duration.svelte";
+
+export interface SvelteDurationOptions
+  extends Pick<
+    DurationProps,
+    | "value"
+    | "unit"
+    | "since"
+    | "format"
+    | "humanize"
+    | "withSuffix"
+    | "locale"
+    | "live"
+  > {}
+
+export const svelteDuration: Action<
+  HTMLElement,
+  undefined | Partial<SvelteDurationOptions>
+>;

--- a/src/svelte-duration.svelte.js
+++ b/src/svelte-duration.svelte.js
@@ -1,0 +1,63 @@
+import { dayjs } from "./dayjs";
+import { formatDuration } from "./duration-format";
+
+/**
+ * @typedef {import("./svelte-duration.svelte").SvelteDurationOptions} SvelteDurationOptions
+ * @typedef {import ("svelte/action").Action<HTMLElement, Partial<SvelteDurationOptions>>} SvelteDurationAction
+ * @type {SvelteDurationAction}
+ */
+export const svelteDuration = (node, options = {}) => {
+  const DEFAULT_INTERVAL = 60 * 1_000;
+
+  /** @type {undefined | NodeJS.Timeout} */
+  let interval;
+
+  const render = (options = {}) => {
+    const value = options.value ?? 0;
+    const unit = options.unit ?? "milliseconds";
+    const since = options.since;
+    const format = options.format ?? "HH:mm:ss";
+    const humanize = options.humanize ?? false;
+    const withSuffix = options.withSuffix ?? false;
+    const locale = options.locale ?? "en";
+
+    const result =
+      since === undefined
+        ? formatDuration({ value, unit, format, humanize, withSuffix, locale })
+        : formatDuration({
+            value: dayjs().diff(dayjs(since)),
+            unit: "milliseconds",
+            format,
+            humanize,
+            withSuffix,
+            locale,
+          });
+
+    node.setAttribute("datetime", result.datetime);
+    node.textContent = result.formatted;
+  };
+
+  const updateDuration = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+
+    render(options);
+
+    const live = options.live ?? false;
+    if (options.since !== undefined && live !== false) {
+      interval = setInterval(
+        () => render(options),
+        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
+      );
+    }
+  };
+
+  updateDuration(options);
+
+  return {
+    update: updateDuration,
+    destroy() {
+      clearInterval(interval);
+    },
+  };
+};

--- a/tests/Duration.test.svelte
+++ b/tests/Duration.test.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import { Duration, dayjs } from "svelte-time";
+</script>
+
+<!-- Default: format="HH:mm:ss" -->
+<Duration
+  data-test="default"
+  value={0}
+/>
+<Duration
+  data-test="basic"
+  value={3661000}
+/>
+
+<!-- Unit -->
+<Duration
+  data-test="value-seconds"
+  value={90}
+  unit="seconds"
+  format="mm:ss"
+/>
+
+<!-- Rollup: excess magnitude rolls into the largest present token -->
+<Duration
+  data-test="rollup-minutes"
+  value={5400000}
+  format="mm:ss"
+/>
+<Duration
+  data-test="rollup-hours"
+  value={90000000}
+  format="HH:mm:ss"
+/>
+
+<!-- Flexible value: ISO 8601 string and dayjs Duration instance -->
+<Duration
+  data-test="value-iso-string"
+  value="PT2H"
+/>
+<Duration
+  data-test="value-duration-object"
+  value={dayjs.duration(2, "hours")}
+/>
+
+<!-- Humanize -->
+<Duration
+  data-test="humanize-default"
+  value={3600000}
+  humanize
+/>
+<Duration
+  data-test="humanize-with-suffix"
+  value={3600000}
+  humanize
+  withSuffix
+/>
+
+<!-- Locale -->
+<Duration
+  data-test="locale-de"
+  value={3600000}
+  humanize
+  locale="de"
+/>
+<Duration
+  data-test="locale-es"
+  value={120000}
+  humanize
+  locale="es"
+/>
+
+<!-- since + live (elapsed/stopwatch mode) -->
+<Duration
+  data-test="since"
+  since={new Date().toISOString()}
+  live
+  format="HH:mm:ss"
+/>

--- a/tests/Duration.test.ts
+++ b/tests/Duration.test.ts
@@ -1,0 +1,122 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import Duration from "./Duration.test.svelte";
+
+describe("Duration", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("renders as a <time> element with an ISO 8601 datetime attribute", () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic"]');
+    expect(el.tagName).toEqual("TIME");
+    expect(el.getAttribute("datetime")).toEqual("PT1H1M1S");
+  });
+
+  test("default value and format", () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="default"]').textContent).toEqual("00:00:00");
+    expect(
+      getElement('[data-test="default"]').getAttribute("datetime"),
+    ).toEqual("P0D");
+    expect(getElement('[data-test="basic"]').textContent).toEqual("01:01:01");
+  });
+
+  test("unit converts a numeric value before formatting", () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="value-seconds"]');
+    expect(el.textContent).toEqual("01:30");
+    expect(el.getAttribute("datetime")).toEqual("PT1M30S");
+  });
+
+  test("rollup: magnitude larger than the format's largest token rolls up instead of dropping", () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    // 90 minutes with format="mm:ss" -> "90:00", not "30:00"
+    const minutes = getElement('[data-test="rollup-minutes"]');
+    expect(minutes.textContent).toEqual("90:00");
+    expect(minutes.getAttribute("datetime")).toEqual("PT1H30M");
+
+    // 25 hours with format="HH:mm:ss" -> "25:00:00", not "01:00:00"
+    const hours = getElement('[data-test="rollup-hours"]');
+    expect(hours.textContent).toEqual("25:00:00");
+  });
+
+  test("value accepts an ISO 8601 duration string or a dayjs Duration instance", () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="value-iso-string"]').textContent).toEqual(
+      "02:00:00",
+    );
+    expect(
+      getElement('[data-test="value-duration-object"]').textContent,
+    ).toEqual("02:00:00");
+  });
+
+  test("humanize and withSuffix", () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="humanize-default"]').textContent).toEqual(
+      "an hour",
+    );
+    expect(
+      getElement('[data-test="humanize-with-suffix"]').textContent,
+    ).toEqual("in an hour");
+  });
+
+  test("locale formatting", async () => {
+    await import("dayjs/locale/de");
+    await import("dayjs/locale/es");
+
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="locale-de"]').textContent).toEqual(
+      "eine Stunde",
+    );
+    expect(getElement('[data-test="locale-es"]').textContent).toEqual(
+      "2 minutos",
+    );
+  });
+
+  test("since + live: renders elapsed time and ticks as time passes", async () => {
+    instance = mount(Duration, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="since"]');
+    expect(el.textContent).toEqual("00:00:00");
+
+    vi.advanceTimersByTime(65_000);
+    await tick();
+
+    expect(el.textContent).toEqual("00:01:05");
+  });
+});

--- a/tests/DurationAttachment.test.svelte
+++ b/tests/DurationAttachment.test.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: `duration` is used in the {@attach} directives below
+  import { duration } from "svelte-time";
+</script>
+
+<time
+  data-test="basic"
+  {@attach duration({ value: 3661000 })}
+></time>
+
+<time
+  data-test="rollup"
+  {@attach duration({ value: 5400000, format: "mm:ss" })}
+></time>
+
+<time
+  data-test="humanize"
+  {@attach duration({ value: 3600000, humanize: true, withSuffix: true })}
+></time>
+
+<time
+  data-test="since"
+  {@attach duration({
+    since: new Date().toISOString(),
+    live: true,
+    format: "HH:mm:ss",
+  })}
+></time>

--- a/tests/DurationAttachment.test.ts
+++ b/tests/DurationAttachment.test.ts
@@ -1,0 +1,65 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import DurationAttachment from "./DurationAttachment.test.svelte";
+
+describe("duration attachment", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("basic render: textContent and datetime are correct", () => {
+    instance = mount(DurationAttachment, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic"]');
+    expect(el.textContent).toEqual("01:01:01");
+    expect(el.getAttribute("datetime")).toEqual("PT1H1M1S");
+  });
+
+  test("rollup: excess magnitude rolls into the largest present token", () => {
+    instance = mount(DurationAttachment, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="rollup"]').textContent).toEqual("90:00");
+  });
+
+  test("humanize + withSuffix", () => {
+    instance = mount(DurationAttachment, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="humanize"]').textContent).toEqual(
+      "in an hour",
+    );
+  });
+
+  test("since + live: ticks as time passes via the shared clock", async () => {
+    instance = mount(DurationAttachment, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="since"]');
+    expect(el.textContent).toEqual("00:00:00");
+
+    vi.advanceTimersByTime(65_000);
+    await tick();
+
+    expect(el.textContent).toEqual("00:01:05");
+  });
+});

--- a/tests/SvelteDurationAction.test.svelte
+++ b/tests/SvelteDurationAction.test.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { svelteDuration } from "svelte-time";
+</script>
+
+<time
+  data-test="basic"
+  use:svelteDuration={{ value: 3661000 }}
+></time>
+<span
+  data-test="basic-span"
+  use:svelteDuration={{ value: 3661000 }}
+></span>
+
+<time
+  data-test="rollup"
+  use:svelteDuration={{ value: 5400000, format: "mm:ss" }}
+></time>
+
+<time
+  data-test="humanize"
+  use:svelteDuration={{ value: 3600000, humanize: true, withSuffix: true }}
+></time>
+
+<time
+  data-test="locale"
+  use:svelteDuration={{ value: 3600000, humanize: true, locale: "de" }}
+></time>
+
+<time
+  data-test="since"
+  use:svelteDuration={{
+    since: new Date().toISOString(),
+    live: 1000,
+    format: "HH:mm:ss",
+  }}
+></time>

--- a/tests/SvelteDurationAction.test.ts
+++ b/tests/SvelteDurationAction.test.ts
@@ -1,0 +1,86 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import SvelteDurationAction from "./SvelteDurationAction.test.svelte";
+
+describe("svelteDuration action", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("sets datetime and text on a <time> element", () => {
+    instance = mount(SvelteDurationAction, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic"]');
+    expect(el.tagName).toEqual("TIME");
+    expect(el.textContent).toEqual("01:01:01");
+    expect(el.getAttribute("datetime")).toEqual("PT1H1M1S");
+  });
+
+  test("works on non-time elements too", () => {
+    instance = mount(SvelteDurationAction, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic-span"]');
+    expect(el.tagName).toEqual("SPAN");
+    expect(el.textContent).toEqual("01:01:01");
+  });
+
+  test("rollup: excess magnitude rolls into the largest present token", () => {
+    instance = mount(SvelteDurationAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="rollup"]').textContent).toEqual("90:00");
+  });
+
+  test("humanize + withSuffix", () => {
+    instance = mount(SvelteDurationAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="humanize"]').textContent).toEqual(
+      "in an hour",
+    );
+  });
+
+  test("locale", async () => {
+    await import("dayjs/locale/de");
+
+    instance = mount(SvelteDurationAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="locale"]').textContent).toEqual(
+      "eine Stunde",
+    );
+  });
+
+  test("since + live: ticks as time passes", async () => {
+    instance = mount(SvelteDurationAction, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="since"]');
+    expect(el.textContent).toEqual("00:00:00");
+
+    vi.advanceTimersByTime(5_000);
+    await tick();
+
+    expect(el.textContent).toEqual("00:00:05");
+  });
+});

--- a/tests/examples/DurationAttachmentExample.svelte
+++ b/tests/examples/DurationAttachmentExample.svelte
@@ -1,0 +1,6 @@
+<script>
+  // biome-ignore lint/correctness/noUnusedImports: `duration` is used in the {@attach} directive below
+  import { duration } from "svelte-time";
+</script>
+
+<time {@attach duration({ value: 3661000 })}></time>

--- a/tests/examples/DurationBasic.svelte
+++ b/tests/examples/DurationBasic.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { Duration } from "svelte-time";
+</script>
+
+<div>
+  <!-- Default format: "HH:mm:ss" -->
+  <Duration value={3661000} />
+</div>
+
+<div>
+  <!-- unit converts a plain number before formatting -->
+  <Duration
+    value={90}
+    unit="seconds"
+    format="mm:ss"
+  />
+</div>
+
+<div>
+  <!-- Magnitude larger than the format's largest token rolls up -->
+  <Duration
+    value={5400000}
+    format="mm:ss"
+  />
+</div>

--- a/tests/examples/DurationHumanize.svelte
+++ b/tests/examples/DurationHumanize.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { Duration } from "svelte-time";
+</script>
+
+<div>
+  <Duration
+    value={3600000}
+    humanize
+  />
+  <!-- Output: "an hour" -->
+</div>
+
+<div>
+  <Duration
+    value={3600000}
+    humanize
+    withSuffix
+  />
+  <!-- Output: "in an hour" -->
+</div>

--- a/tests/examples/DurationLocale.svelte
+++ b/tests/examples/DurationLocale.svelte
@@ -1,0 +1,13 @@
+<script>
+  import "dayjs/locale/de";
+  import { Duration } from "svelte-time";
+</script>
+
+<div>
+  <Duration
+    value={3600000}
+    humanize
+    locale="de"
+  />
+  <!-- Output: "eine Stunde" -->
+</div>

--- a/tests/examples/DurationSince.svelte
+++ b/tests/examples/DurationSince.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { Duration } from "svelte-time";
+
+  const since = new Date().toISOString();
+</script>
+
+<!-- Elapsed time since `since`, ticking live -->
+<Duration
+  {since}
+  live
+  format="HH:mm:ss"
+/>

--- a/tests/examples/SvelteDurationAction.svelte
+++ b/tests/examples/SvelteDurationAction.svelte
@@ -1,0 +1,5 @@
+<script>
+  import { svelteDuration } from "svelte-time";
+</script>
+
+<time use:svelteDuration={{ value: 3661000 }}></time>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,8 +2,11 @@ import * as API from "svelte-time";
 
 test("Library has exports", () => {
   expect(Object.keys(API).sort()).toEqual([
+    "Duration",
     "dayjs",
     "default",
+    "duration",
+    "svelteDuration",
     "svelteTime",
     "time",
   ]);

--- a/tests/ssr/Duration.ssr.test.ts
+++ b/tests/ssr/Duration.ssr.test.ts
@@ -1,0 +1,43 @@
+import { render } from "svelte/server";
+import { Duration } from "svelte-time";
+import DurationAttachment from "../DurationAttachment.test.svelte";
+
+describe("Duration (SSR)", () => {
+  test("renders a populated <time> element on the server", () => {
+    const { body } = render(Duration, { props: { value: 3661000 } });
+    expect(body).toContain("<time");
+    expect(body).toContain("01:01:01");
+    expect(body).toContain('datetime="PT1H1M1S"');
+  });
+
+  test("humanize renders on the server", () => {
+    const { body } = render(Duration, {
+      props: { value: 3600000, humanize: true },
+    });
+    expect(body).toContain("an hour");
+  });
+
+  test("since + live mode starts no timers on the server", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    render(Duration, {
+      props: { since: new Date().toISOString(), live: true },
+    });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("duration attachment (SSR)", () => {
+  test("attachments do not run during server rendering", () => {
+    const { body } = render(DurationAttachment);
+    expect(body).toContain('<time data-test="basic"></time>');
+    expect(body).not.toContain("datetime=");
+  });
+
+  test("live mode starts no timers on the server", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    render(DurationAttachment);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/tests/types.test-d.ts
+++ b/tests/types.test-d.ts
@@ -1,7 +1,13 @@
 import type { Snippet } from "svelte";
 import type { Attachment } from "svelte/attachments";
-import type { Locales, SvelteTimeOptions, TimeProps } from "svelte-time";
-import { time } from "svelte-time";
+import type {
+  DurationProps,
+  Locales,
+  SvelteDurationOptions,
+  SvelteTimeOptions,
+  TimeProps,
+} from "svelte-time";
+import { duration, time } from "svelte-time";
 import { expectTypeOf, test } from "vitest";
 
 test("format is a plain string", () => {
@@ -34,4 +40,30 @@ test("time attachment returns an Attachment<HTMLElement>", () => {
   expectTypeOf(time)
     .parameter(0)
     .toEqualTypeOf<Partial<SvelteTimeOptions> | undefined>();
+});
+
+test("Duration value accepts number, string, object, or a dayjs Duration", () => {
+  expectTypeOf<number>().toExtend<DurationProps["value"]>();
+  expectTypeOf<string>().toExtend<DurationProps["value"]>();
+  expectTypeOf<undefined>().toExtend<DurationProps["value"]>();
+});
+
+test("Duration children accepts a snippet receiving the formatted string", () => {
+  expectTypeOf<DurationProps["children"]>().toEqualTypeOf<
+    Snippet<[string]> | undefined
+  >();
+});
+
+test("svelteDuration action options are exported", () => {
+  expectTypeOf<SvelteDurationOptions["since"]>().not.toBeNever();
+  expectTypeOf<SvelteDurationOptions["withSuffix"]>().toEqualTypeOf<
+    boolean | undefined
+  >();
+});
+
+test("duration attachment returns an Attachment<HTMLElement>", () => {
+  expectTypeOf(duration()).toEqualTypeOf<Attachment<HTMLElement>>();
+  expectTypeOf(duration)
+    .parameter(0)
+    .toEqualTypeOf<Partial<SvelteDurationOptions> | undefined>();
 });


### PR DESCRIPTION
## Summary

Closes #71
Closes #72

Adds duration formatting (a span of time: video length, countdown, stopwatch) as a first-class citizen alongside `Time` (a point in time), per the request in #71.

- **`Duration` component**, **`svelteDuration` action**, and **`duration` attachment** — full parity with `Time`'s three entry points.
- `value` accepts a number + `unit`, an ISO 8601 duration string (`"PT1H30M"`), a plain object of unit fields, or a dayjs `Duration` instance.
- `format` (default `"HH:mm:ss"`), `humanize` + `withSuffix`, `locale` — same shape as `Time`'s props where it made sense.
- **`since` + `live`**: an elapsed/stopwatch mode with no equivalent in the original approach — reuses the shared-clock ticker `Time`'s `relative live` mode already depends on.
- Uses dayjs's `duration` plugin (already a dependency via `dayjs`), extended once on the existing shared `src/dayjs.js`.

## Tradeoffs vs. the earlier attempt in #72

- **Shared formatting util instead of duplicated logic.** #72 hand-rolled the same format-token regex replacement three times (component, action, and again inside the action's live-interval callback). This PR factors it into one function, `formatDuration()` in `src/duration-format.js`, used by all three entry points — one implementation to test and fix instead of three copies that can drift.
- **Format rollup, not raw dayjs passthrough.** dayjs's own `duration.format()` is decomposed-only: `format="mm:ss"` on 90 minutes silently drops the hour and renders `"30:00"`. That's surprising for the most common use case (a media player or timer). This PR rolls any magnitude above the largest token present in the format string into that token, so `"mm:ss"` on 90 minutes renders `"90:00"`. This is the one meaningfully new piece of logic in the PR (see `renderTemplate` in `duration-format.js`), and it's exactly what #72 was trying to do with its buggy, triplicated version — just implemented once and covered by tests.
- **`withSuffix` instead of `withoutSuffix`.** `Time`'s `withoutSuffix` (default `false`) makes sense because `relative` mode is suffix-on by default. `Duration`'s `humanize()` has the opposite default in dayjs itself (suffix-off, e.g. "an hour" not "in an hour") — correct for a plain span, since a video length isn't inherently relative to now. Naming the prop `withSuffix` (default `false`) matches that default directly instead of hiding an inverted default behind a same-named-but-differently-behaved prop.
- **No pointless `live` on plain `value`.** #72's `live` prop ticked an interval even when only `value` was set, but that's a no-op unless the consumer separately mutates `value` themselves — in which case Svelte's own reactivity already re-renders, making the timer redundant. This PR only wires up ticking for the new `since` mode (elapsed/stopwatch), where "now" genuinely changes on its own and a shared clock is actually needed — the same reason `Time`'s `relative live` needs one.
- **One shared `dayjs.js`, not a `dayjs-time.js`/`dayjs-duration.js` split.** #72 split the shared dayjs instance in two to keep the `duration` plugin out of `Time`-only bundles, which forced `Time.svelte` to switch import paths. The `duration` plugin is small (~4.8KB min / ~1.7KB gzip) — the same tradeoff already made for `relativeTime`. Not worth the extra module/indirection for that.
