### PR TITLE
test: add more regression tests

### DIFF
--- a/tests/DatetimeAttribute.test.ts
+++ b/tests/DatetimeAttribute.test.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { flushSync, mount, unmount } from "svelte";
-import Time, { svelteTime } from "svelte-time";
+import Time, { svelteTime, time } from "svelte-time";
 
 describe("datetime attribute contract", () => {
   const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
@@ -38,11 +38,19 @@ describe("datetime attribute contract", () => {
     return node;
   }
 
+  function renderAttachment(timestamp: unknown) {
+    const node = document.createElement("time");
+    node.setAttribute("data-test", "attachment");
+    document.body.appendChild(node);
+    time({ timestamp, format: "YYYY-MM-DD" })(node);
+    return node;
+  }
+
   test.each([
     ["Date", new Date("2024-01-01T00:00:00.000Z")],
     ["Dayjs", dayjs("2024-01-01T00:00:00.000Z")],
     ["number", 1e10],
-  ])("%s inputs are normalized to ISO 8601 in both render paths", (_, timestamp) => {
+  ])("%s inputs are normalized to ISO 8601 in all three render paths", (_, timestamp) => {
     const component = renderComponent(timestamp);
     expect(component.getAttribute("datetime")).toMatch(ISO);
 
@@ -54,9 +62,14 @@ describe("datetime attribute contract", () => {
 
     const action = renderAction(timestamp);
     expect(action.getAttribute("datetime")).toMatch(ISO);
+
+    document.body.innerHTML = "";
+
+    const attachment = renderAttachment(timestamp);
+    expect(attachment.getAttribute("datetime")).toMatch(ISO);
   });
 
-  test("string inputs pass through as-is in both render paths", () => {
+  test("string inputs pass through as-is in all three render paths", () => {
     const timestamp = "2020-02-01";
 
     const component = renderComponent(timestamp);
@@ -70,9 +83,14 @@ describe("datetime attribute contract", () => {
 
     const action = renderAction(timestamp);
     expect(action.getAttribute("datetime")).toEqual(timestamp);
+
+    document.body.innerHTML = "";
+
+    const attachment = renderAttachment(timestamp);
+    expect(attachment.getAttribute("datetime")).toEqual(timestamp);
   });
 
-  test("invalid inputs omit the datetime attribute in both render paths", () => {
+  test("invalid inputs omit the datetime attribute in all three render paths", () => {
     const timestamp = "not a date";
 
     const component = renderComponent(timestamp);
@@ -86,5 +104,10 @@ describe("datetime attribute contract", () => {
 
     const action = renderAction(timestamp);
     expect(action.hasAttribute("datetime")).toEqual(false);
+
+    document.body.innerHTML = "";
+
+    const attachment = renderAttachment(timestamp);
+    expect(attachment.hasAttribute("datetime")).toEqual(false);
   });
 });

--- a/tests/RelativeStyle.test.svelte
+++ b/tests/RelativeStyle.test.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import "dayjs/locale/de"; // German
   import Time from "svelte-time";
 </script>
 
@@ -7,6 +8,16 @@
   data-test="micro"
   relative
   relativeStyle="micro"
+  timestamp="2023-12-28T00:00:00.000Z"
+  format="MMM DD, YYYY"
+/>
+
+<!-- relativeStyle="micro" ignores locale — English unit letters regardless -->
+<Time
+  data-test="micro-german-locale"
+  relative
+  relativeStyle="micro"
+  locale="de"
   timestamp="2023-12-28T00:00:00.000Z"
   format="MMM DD, YYYY"
 />

--- a/tests/RelativeStyle.test.ts
+++ b/tests/RelativeStyle.test.ts
@@ -60,6 +60,20 @@ describe("Time component with relativeStyle prop", () => {
     );
   });
 
+  test('relativeStyle="micro" ignores locale — always renders English unit letters', () => {
+    const target = document.body;
+    instance = mount(RelativeStyleTest, { target });
+    flushSync();
+
+    const element = getElement('[data-test="micro-german-locale"]');
+    expect(element.innerHTML).toEqual("4d");
+    // the title still localizes, since it's the plain absolute `format` —
+    // only the micro body text is locale-independent
+    expect(element.title).toEqual(
+      dayjs("2023-12-28T00:00:00.000Z").locale("de").format("MMM DD, YYYY"),
+    );
+  });
+
   test('relativeStyle="micro" is a no-op without relative', () => {
     const target = document.body;
     instance = mount(RelativeStyleTest, { target });

--- a/tests/SvelteTimeAction.test.ts
+++ b/tests/SvelteTimeAction.test.ts
@@ -3,6 +3,7 @@ import { flushSync, mount, unmount } from "svelte";
 import { svelteTime } from "../src/svelte-time.svelte.js";
 import SvelteTimeAction from "./examples/SvelteTimeAction.svelte";
 import SvelteTimeActionStateRaw from "./examples/SvelteTimeActionStateRaw.svelte";
+import SvelteTimeActionStateRawMutate from "./examples/SvelteTimeActionStateRawMutate.svelte";
 
 describe("svelte-time-action", () => {
   let instance: null | ReturnType<typeof mount> = null;
@@ -148,5 +149,27 @@ describe("svelte-time-action", () => {
 
     expect(timeElement.innerText).toEqual(dayjs("2025-04-02").format(format));
     expect(timeElement.getAttribute("datetime")).toEqual("2025-04-02");
+  });
+
+  // Counterpart to the reassignment regression test above for
+  // https://github.com/metonym/svelte-time/issues/62 — pins the other half
+  // of the documented boundary: $state.raw is not deeply reactive, so
+  // mutating a field on the same reference must NOT update the action.
+  test("does not update when a field on $state.raw is mutated in place", async () => {
+    const target = document.body;
+    instance = mount(SvelteTimeActionStateRawMutate, { target });
+    flushSync();
+
+    const timeElement = getElement("time");
+    const format = "dddd @ h:mm A · MMMM D, YYYY";
+    expect(timeElement.innerText).toEqual(dayjs("2021-02-02").format(format));
+    expect(timeElement.getAttribute("datetime")).toEqual("2021-02-02");
+
+    const button = getElement("button");
+    button.click();
+    flushSync();
+
+    expect(timeElement.innerText).toEqual(dayjs("2021-02-02").format(format));
+    expect(timeElement.getAttribute("datetime")).toEqual("2021-02-02");
   });
 });

--- a/tests/SvelteTimeParity.test.ts
+++ b/tests/SvelteTimeParity.test.ts
@@ -258,3 +258,106 @@ describe("component/action/attachment parity for relativeThreshold", () => {
     unmount(instance);
   });
 });
+
+// tz, relativeStyle, and relativeThreshold each shipped independently
+// (#87, #89, #88) and are well covered in isolation above, but nothing
+// exercises them together on one element — this pins the interaction.
+describe("component/action/attachment parity for tz + relativeStyle + relativeThreshold combined", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  const FORMAT = "YYYY-MM-DDTHH:mm:ss";
+  const TZ = "America/Toronto";
+  const THRESHOLD = 2 * 60 * 60 * 1_000; // 2 hours
+
+  test("under threshold: all three surfaces render a micro value with a tz-formatted title", () => {
+    const timestamp = dayjs().subtract(1, "hour").toISOString();
+    const options = {
+      relative: true,
+      relativeStyle: "micro",
+      relativeThreshold: THRESHOLD,
+      tz: TZ,
+      format: FORMAT,
+      timestamp,
+    } as const;
+    const expectedTitle = dayjs(timestamp).tz(TZ).format(FORMAT);
+
+    const instance = mount(Time, {
+      target: document.body,
+      props: { "data-test": "component", ...options },
+    });
+    flushSync();
+
+    const actionNode = document.createElement("time");
+    document.body.appendChild(actionNode);
+    const action = svelteTime(actionNode, options);
+
+    const attachmentNode = document.createElement("time");
+    document.body.appendChild(attachmentNode);
+    time(options)(attachmentNode);
+
+    const component = document.querySelector(
+      '[data-test="component"]',
+    ) as HTMLElement;
+
+    expect(component.textContent?.trim()).toEqual("1h");
+    expect(actionNode.textContent?.trim()).toEqual("1h");
+    expect(attachmentNode.textContent?.trim()).toEqual("1h");
+
+    expect(component.title).toEqual(expectedTitle);
+    expect(actionNode.title).toEqual(expectedTitle);
+    expect(attachmentNode.title).toEqual(expectedTitle);
+
+    action?.destroy?.();
+    unmount(instance);
+  });
+
+  test("past threshold: all three surfaces fall back to the tz-formatted absolute value, no title", () => {
+    const timestamp = dayjs().subtract(3, "hour").toISOString();
+    const options = {
+      relative: true,
+      relativeStyle: "micro",
+      relativeThreshold: THRESHOLD,
+      tz: TZ,
+      format: FORMAT,
+      timestamp,
+    } as const;
+    const expected = dayjs(timestamp).tz(TZ).format(FORMAT);
+
+    const instance = mount(Time, {
+      target: document.body,
+      props: { "data-test": "component", ...options },
+    });
+    flushSync();
+
+    const actionNode = document.createElement("time");
+    document.body.appendChild(actionNode);
+    const action = svelteTime(actionNode, options);
+
+    const attachmentNode = document.createElement("time");
+    document.body.appendChild(attachmentNode);
+    time(options)(attachmentNode);
+
+    const component = document.querySelector(
+      '[data-test="component"]',
+    ) as HTMLElement;
+
+    expect(component.textContent?.trim()).toEqual(expected);
+    expect(actionNode.textContent?.trim()).toEqual(expected);
+    expect(attachmentNode.textContent?.trim()).toEqual(expected);
+
+    expect(component.title).toBeFalsy();
+    expect(actionNode.title).toBeFalsy();
+    expect(attachmentNode.title).toBeFalsy();
+
+    action?.destroy?.();
+    unmount(instance);
+  });
+});

--- a/tests/Timezone.test.ts
+++ b/tests/Timezone.test.ts
@@ -1,7 +1,7 @@
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { flushSync, mount, unmount } from "svelte";
-import Time, { dayjs } from "svelte-time";
+import Time, { dayjs, svelteTime, time } from "svelte-time";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -62,5 +62,25 @@ describe("tz prop", () => {
 
     expect(datetimeWithTz).toEqual(datetimeWithoutTz);
     expect(datetimeWithTz).toEqual(TIMESTAMP);
+  });
+
+  // With the plugins extended (unlike TimezoneMissingPlugin.test.ts), an
+  // unrecognized IANA zone name is a distinct, previously-untested failure
+  // mode: it's dayjs/Intl's own RangeError, not svelte-time's "requires the
+  // utc/timezone plugins" message. Pin what actually happens so a future
+  // change can't silently swallow or reword it without a test noticing.
+  test("unknown zone name: propagates dayjs/Intl's own RangeError, not our plugin-guard message", () => {
+    const props = { timestamp: TIMESTAMP, tz: "Not/AZone", format: FORMAT };
+
+    expect(() => render(props)).toThrow(RangeError);
+    expect(() => render(props)).toThrow(/invalid time zone/i);
+
+    const actionNode = document.createElement("time");
+    document.body.appendChild(actionNode);
+    expect(() => svelteTime(actionNode, props)).toThrow(RangeError);
+
+    const attachmentNode = document.createElement("time");
+    document.body.appendChild(attachmentNode);
+    expect(() => time(props)(attachmentNode)).toThrow(RangeError);
   });
 });

--- a/tests/TimezoneMissingPlugin.test.ts
+++ b/tests/TimezoneMissingPlugin.test.ts
@@ -7,7 +7,7 @@ describe("tz prop without utc/timezone plugins extended", () => {
   // Re-importing Time.svelte/dayjs/svelte fresh after vi.resetModules() is
   // slow under parallel worker contention; give it headroom beyond the 5s
   // default to avoid flaking in CI.
-  test("throws a clear, actionable error", async () => {
+  test("component: throws a clear, actionable error", async () => {
     vi.resetModules();
 
     const { dayjs } = await import("../src/dayjs.js");
@@ -31,6 +31,64 @@ describe("tz prop without utc/timezone plugins extended", () => {
       thrown = error;
     } finally {
       if (instance) unmount(instance);
+      document.body.innerHTML = "";
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(
+      /svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins/,
+    );
+  }, 15_000);
+
+  // The throw guard is duplicated independently in svelte-time.svelte.js and
+  // attachment.js (not shared with Time.svelte), so a dropped/typo'd guard in
+  // either would ship silently without its own test.
+  test("action: throws a clear, actionable error", async () => {
+    vi.resetModules();
+
+    const { dayjs } = await import("../src/dayjs.js");
+    expect(typeof (dayjs() as any).tz).not.toEqual("function");
+
+    const { svelteTime } = await import("../src/svelte-time.svelte.js");
+
+    const node = document.createElement("time");
+    document.body.appendChild(node);
+
+    let thrown: unknown;
+    try {
+      svelteTime(node, {
+        timestamp: "2013-11-18T11:55:20Z",
+        tz: "America/Toronto",
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      document.body.innerHTML = "";
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(
+      /svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins/,
+    );
+  }, 15_000);
+
+  test("attachment: throws a clear, actionable error", async () => {
+    vi.resetModules();
+
+    const { dayjs } = await import("../src/dayjs.js");
+    expect(typeof (dayjs() as any).tz).not.toEqual("function");
+
+    const { time } = await import("../src/attachment.js");
+
+    const node = document.createElement("time");
+    document.body.appendChild(node);
+
+    let thrown: unknown;
+    try {
+      time({ timestamp: "2013-11-18T11:55:20Z", tz: "America/Toronto" })(node);
+    } catch (error) {
+      thrown = error;
+    } finally {
       document.body.innerHTML = "";
     }
 

--- a/tests/examples/SvelteTimeActionStateRawMutate.svelte
+++ b/tests/examples/SvelteTimeActionStateRawMutate.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { svelteTime } from "svelte-time";
+
+  let data = $state.raw({
+    timestamp: "2021-02-02",
+    format: "dddd @ h:mm A · MMMM D, YYYY",
+  });
+
+  function mutateField() {
+    // Mutates the same $state.raw reference in place, rather than
+    // reassigning it — $state.raw is not deeply reactive, so this must
+    // NOT trigger the action's update().
+    data.timestamp = "2025-04-02";
+  }
+</script>
+
+<button
+  type="button"
+  onclick={mutateField}
+>
+  Mutate
+</button>
+
+<div>
+  <time use:svelteTime={data}></time>
+</div>

--- a/tests/ssr/Time.ssr.test.ts
+++ b/tests/ssr/Time.ssr.test.ts
@@ -1,6 +1,11 @@
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { render } from "svelte/server";
 import Time, { dayjs } from "svelte-time";
 import TimeChildren from "./TimeChildren.ssr.test.svelte";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 describe("Time (SSR)", () => {
   const TS = "2024-01-01T00:00:00.000Z";
@@ -44,5 +49,66 @@ describe("Time (SSR)", () => {
         "Invalid Date",
       );
     }
+  });
+
+  test("tz prop renders the zoned wall-clock time in the server HTML", () => {
+    const zone = "America/Toronto";
+    const format = "YYYY-MM-DDTHH:mm:ss";
+    const expected = dayjs(TS).tz(zone).format(format);
+
+    const { body } = render(Time, {
+      props: { timestamp: TS, tz: zone, format },
+    });
+
+    expect(body).toContain(expected);
+    // Sanity: the conversion actually changed the wall-clock value.
+    expect(expected).not.toEqual(dayjs(TS).format(format));
+  });
+
+  test('relativeStyle="micro" renders a compact unit in the server HTML', () => {
+    const timestamp = dayjs().subtract(4, "day").toISOString();
+
+    const { body } = render(Time, {
+      props: { timestamp, relative: true, relativeStyle: "micro" },
+    });
+
+    expect(body).toContain(">4d<");
+  });
+
+  test("relativeThreshold: under the threshold still renders relative text with a title, server-side", () => {
+    const threshold = 60 * 60 * 1_000; // 1 hour
+    const timestamp = dayjs().subtract(5, "minute").toISOString();
+    const format = "h:mm a";
+
+    const { body } = render(Time, {
+      props: {
+        timestamp,
+        relative: true,
+        relativeThreshold: threshold,
+        format,
+      },
+    });
+
+    expect(body).toContain(dayjs(timestamp).from(dayjs()));
+    expect(body).toContain(`title="${dayjs(timestamp).format(format)}"`);
+  });
+
+  test("relativeThreshold: renders the absolute format server-side once already past the threshold", () => {
+    const threshold = 60 * 60 * 1_000; // 1 hour
+    const timestamp = dayjs().subtract(2, "hour").toISOString();
+    const format = "h:mm a";
+    const expected = dayjs(timestamp).format(format);
+
+    const { body } = render(Time, {
+      props: {
+        timestamp,
+        relative: true,
+        relativeThreshold: threshold,
+        format,
+      },
+    });
+
+    expect(body).toContain(`>${expected}<`);
+    expect(body).not.toContain("title=");
   });
 });


### PR DESCRIPTION
This branch closes coverage gaps found while triaging the open issues on this repo (tz timezone confusion, the state.raw reactivity thread, micro relative style, and relativeThreshold), specifically for behavior that already ships but was under-tested.

Adds: a negative test proving that mutating a field on a state.raw options object does not update the svelteTime action, since state.raw is not deeply reactive (this is the other half of the existing reassignment regression test). Extends the tz missing-plugin throw test to the action and attachment surfaces, since the guard is duplicated independently in each file rather than shared. Adds a combined test exercising tz, relativeStyle, and relativeThreshold together on one element, since each shipped as a separate PR and was only tested in isolation. Asserts that relativeStyle="micro" ignores the locale prop, matching the documented English-only contract. Pins the behavior for an invalid tz zone name, which surfaces dayjs's own RangeError rather than the plugin-guard message. Extends the datetime attribute contract to cover the time attachment, which previously only had a single basic case. Adds SSR coverage for tz, relativeStyle, and relativeThreshold, none of which had been run through the SSR lane before.

No source changes, test-only. Risk is low: these tests assert on existing, already-shipped behavior rather than changing it, so a failure here would indicate a genuine behavioral gap rather than a new regression. The main thing to watch is the dayjs plugin module-state pattern used in TimezoneMissingPlugin.test.ts and Timezone.test.ts (utc/timezone extension leaks across files sharing a worker), which the new tests follow but which could become fragile if the suite's isolation settings change later.