### PR TITLE
fix(Time,Duration): silence `state_referenced_locally` warning on initial interval

### DIFF
--- a/src/Duration.svelte
+++ b/src/Duration.svelte
@@ -68,6 +68,7 @@
     ...rest
   } = $props();
 
+  import { untrack } from "svelte";
   import { dayjs } from "./dayjs";
   import { formatDuration } from "./duration-format";
   import { liveInterval, sharedNow } from "./ticker";
@@ -78,7 +79,9 @@
   // why this is seeded via `$state` + an effect rather than derived
   // directly from `now` (avoiding a `now` -> interval -> `now` cycle).
   let interval = $state(
-    liveInterval(since === undefined ? 0 : dayjs(since).diff(dayjs())),
+    untrack(() =>
+      liveInterval(since === undefined ? 0 : dayjs(since).diff(dayjs())),
+    ),
   );
 
   $effect(() => {

--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -72,6 +72,7 @@
     ...rest
   } = $props();
 
+  import { untrack } from "svelte";
   import { toDatetime } from "./datetime";
   import { dayjs } from "./dayjs";
   import { microFormat } from "./micro";
@@ -121,7 +122,9 @@
   // directly would make `now` depend on itself. Seeded once from the raw
   // props (not the reactive `day`) since this is only an initial guess —
   // the effect below corrects it as soon as it runs.
-  let interval = $state(liveInterval(dayjs(timestamp).diff(dayjs())));
+  let interval = $state(
+    untrack(() => liveInterval(dayjs(timestamp).diff(dayjs()))),
+  );
 
   $effect(() => {
     if (relative && live === true) {


### PR DESCRIPTION
The vite build was emitting a state_referenced_locally warning in both Time.svelte and Duration.svelte, on the line where the initial interval $state is seeded from a reactive prop (timestamp and since respectively). That read is intentional, it's just a one-time initial guess that an effect corrects afterward, but Svelte's compiler can't tell that from a plain reference and flags it as a likely mistake.

Wrapped the initializer in untrack() in both components so the compiler treats the read as an explicit, intentional snapshot rather than a suspicious local capture. No behavior change, the effect that corrects the interval still runs the same way; this only affects how the initial value is computed and quiets the warning. Build now completes without any Svelte warnings, and the full test suite (142 tests) still passes.