### PR TITLE
feat(locales): annotate generated locale union with human-readable names

### DIFF
--- a/scripts/generate-locales.ts
+++ b/scripts/generate-locales.ts
@@ -3,11 +3,11 @@ import localeDayjs from "dayjs/locale.json" with { type: "json" };
 
 const locales: string[] = [];
 
-for (const { key } of localeDayjs) {
+for (const { key, name } of localeDayjs) {
   if (key === "en") {
-    locales.unshift(`'${key}'`);
+    locales.unshift(`'${key}' /* ${name} */`);
   } else {
-    locales.push(`'${key}'`);
+    locales.push(`'${key}' /* ${name} */`);
   }
 }
 

--- a/src/locales.d.ts
+++ b/src/locales.d.ts
@@ -1,145 +1,145 @@
 /** @default "en" */
 export type Locales =
-  | "en"
-  | "af"
-  | "am"
-  | "ar-dz"
-  | "ar-iq"
-  | "ar-kw"
-  | "ar-ly"
-  | "ar-ma"
-  | "ar-sa"
-  | "ar-tn"
-  | "ar"
-  | "az"
-  | "be"
-  | "bg"
-  | "bi"
-  | "bm"
-  | "bn-bd"
-  | "bn"
-  | "bo"
-  | "br"
-  | "bs"
-  | "ca"
-  | "cs"
-  | "cv"
-  | "cy"
-  | "de-at"
-  | "da"
-  | "de-ch"
-  | "de"
-  | "dv"
-  | "el"
-  | "en-au"
-  | "en-ca"
-  | "en-gb"
-  | "en-ie"
-  | "en-il"
-  | "en-in"
-  | "en-nz"
-  | "en-sg"
-  | "en-tt"
-  | "eo"
-  | "es-do"
-  | "es-mx"
-  | "es-pr"
-  | "es-us"
-  | "et"
-  | "es"
-  | "eu"
-  | "fa"
-  | "fo"
-  | "fi"
-  | "fr-ca"
-  | "fr-ch"
-  | "fr"
-  | "fy"
-  | "ga"
-  | "gd"
-  | "gom-latn"
-  | "gl"
-  | "gu"
-  | "he"
-  | "hi"
-  | "hr"
-  | "hu"
-  | "ht"
-  | "hy-am"
-  | "id"
-  | "is"
-  | "it-ch"
-  | "it"
-  | "ja"
-  | "jv"
-  | "ka"
-  | "kk"
-  | "km"
-  | "kn"
-  | "ko"
-  | "ku"
-  | "ky"
-  | "lb"
-  | "lo"
-  | "lt"
-  | "lv"
-  | "me"
-  | "mi"
-  | "mk"
-  | "ml"
-  | "mn"
-  | "mr"
-  | "ms-my"
-  | "ms"
-  | "mt"
-  | "my"
-  | "nb"
-  | "ne"
-  | "nl-be"
-  | "nl"
-  | "pl"
-  | "pt-br"
-  | "pt"
-  | "rn"
-  | "ro"
-  | "ru"
-  | "rw"
-  | "sd"
-  | "se"
-  | "si"
-  | "sk"
-  | "sl"
-  | "sq"
-  | "sr-cyrl"
-  | "ss"
-  | "sv-fi"
-  | "sr"
-  | "sv"
-  | "sw"
-  | "ta"
-  | "te"
-  | "tet"
-  | "tg"
-  | "th"
-  | "tk"
-  | "tl-ph"
-  | "tlh"
-  | "tr"
-  | "tzl"
-  | "tzm-latn"
-  | "tzm"
-  | "ug-cn"
-  | "uk"
-  | "ur"
-  | "uz-latn"
-  | "uz"
-  | "vi"
-  | "x-pseudo"
-  | "yo"
-  | "zh-cn"
-  | "zh-hk"
-  | "zh-tw"
-  | "zh"
-  | "oc-lnc"
-  | "nn"
-  | "pa-in";
+  | "en" /* English */
+  | "af" /* Afrikaans */
+  | "am" /* Amharic */
+  | "ar-dz" /* Arabic (Algeria) */
+  | "ar-iq" /*  Arabic (Iraq) */
+  | "ar-kw" /* Arabic (Kuwait) */
+  | "ar-ly" /* Arabic (Lybia) */
+  | "ar-ma" /* Arabic (Morocco) */
+  | "ar-sa" /* Arabic (Saudi Arabia) */
+  | "ar-tn" /*  Arabic (Tunisia) */
+  | "ar" /* Arabic */
+  | "az" /* Azerbaijani */
+  | "be" /* Belarusian */
+  | "bg" /* Bulgarian */
+  | "bi" /* Bislama */
+  | "bm" /* Bambara */
+  | "bn-bd" /* Bengali (Bangladesh) */
+  | "bn" /* Bengali */
+  | "bo" /* Tibetan */
+  | "br" /* Breton */
+  | "bs" /* Bosnian */
+  | "ca" /* Catalan */
+  | "cs" /* Czech */
+  | "cv" /* Chuvash */
+  | "cy" /* Welsh */
+  | "da" /* Danish */
+  | "de-at" /* German (Austria) */
+  | "de" /* German */
+  | "de-ch" /* German (Switzerland) */
+  | "dv" /* Maldivian */
+  | "en-au" /* English (Australia) */
+  | "el" /* Greek */
+  | "en-ca" /* English (Canada) */
+  | "en-gb" /* English (United Kingdom) */
+  | "en-ie" /* English (Ireland) */
+  | "en-il" /* English (Israel) */
+  | "en-in" /* English (India) */
+  | "en-nz" /* English (New Zealand) */
+  | "en-sg" /* English (Singapore) */
+  | "en-tt" /* English (Trinidad & Tobago) */
+  | "eo" /* Esperanto */
+  | "es-do" /* Spanish (Dominican Republic) */
+  | "es-mx" /* Spanish (Mexico) */
+  | "es-pr" /* Spanish (Puerto Rico) */
+  | "es-us" /* Spanish (United States) */
+  | "es" /* Spanish */
+  | "et" /* Estonian */
+  | "eu" /* Basque */
+  | "fa" /* Persian */
+  | "fi" /* Finnish */
+  | "fo" /* Faroese */
+  | "fr-ca" /* French (Canada) */
+  | "fr-ch" /* French (Switzerland) */
+  | "fr" /* French */
+  | "fy" /* Frisian */
+  | "ga" /* Irish or Irish Gaelic */
+  | "gl" /* Galician */
+  | "gom-latn" /* Konkani Latin script */
+  | "gd" /* Scottish Gaelic */
+  | "gu" /* Gujarati */
+  | "he" /* Hebrew */
+  | "hi" /* Hindi */
+  | "hr" /* Croatian */
+  | "ht" /* Haitian Creole (Haiti) */
+  | "hu" /* Hungarian */
+  | "hy-am" /* Armenian */
+  | "id" /* Indonesian */
+  | "is" /* Icelandic */
+  | "it-ch" /* Italian (Switzerland) */
+  | "it" /* Italian */
+  | "ja" /* Japanese */
+  | "jv" /* Javanese */
+  | "ka" /* Georgian */
+  | "kk" /* Kazakh */
+  | "km" /* Cambodian */
+  | "kn" /* Kannada */
+  | "ko" /* Korean */
+  | "ku" /* Kurdish */
+  | "ky" /* Kyrgyz */
+  | "lb" /* Luxembourgish */
+  | "lo" /* Lao */
+  | "lt" /* Lithuanian */
+  | "lv" /* Latvian */
+  | "me" /* Montenegrin */
+  | "mi" /* Maori */
+  | "mk" /* Macedonian */
+  | "ml" /* Malayalam */
+  | "mn" /* Mongolian */
+  | "mr" /* Marathi */
+  | "ms-my" /* Malay */
+  | "ms" /* Malay */
+  | "mt" /* Maltese (Malta) */
+  | "my" /* Burmese */
+  | "nb" /* Norwegian Bokmål */
+  | "ne" /* Nepalese */
+  | "nl-be" /* Dutch (Belgium) */
+  | "nl" /* Dutch */
+  | "nn" /* Nynorsk */
+  | "oc-lnc" /* Occitan, lengadocian dialecte */
+  | "pa-in" /* Punjabi (India) */
+  | "pl" /* Polish */
+  | "pt-br" /* Portuguese (Brazil) */
+  | "pt" /* Portuguese */
+  | "rn" /* Kirundi */
+  | "ro" /* Romanian */
+  | "ru" /* Russian */
+  | "rw" /* Kinyarwanda (Rwanda) */
+  | "sd" /* Sindhi */
+  | "se" /* Northern Sami */
+  | "si" /* Sinhalese */
+  | "sk" /* Slovak */
+  | "sl" /* Slovenian */
+  | "sq" /* Albanian */
+  | "sr-cyrl" /* Serbian Cyrillic */
+  | "sr" /* Serbian */
+  | "ss" /* siSwati */
+  | "sv-fi" /* Finland Swedish */
+  | "sv" /* Swedish */
+  | "sw" /* Swahili */
+  | "ta" /* Tamil */
+  | "te" /* Telugu */
+  | "tet" /* Tetun Dili (East Timor) */
+  | "tg" /* Tajik */
+  | "tk" /* Turkmen */
+  | "th" /* Thai */
+  | "tl-ph" /* Tagalog (Philippines) */
+  | "tr" /* Turkish */
+  | "tlh" /* Klingon */
+  | "tzm-latn" /* Central Atlas Tamazight Latin */
+  | "tzm" /* Central Atlas Tamazight */
+  | "tzl" /* Talossan */
+  | "ug-cn" /* Uyghur (China) */
+  | "uk" /* Ukrainian */
+  | "ur" /* Urdu */
+  | "uz-latn" /* Uzbek Latin */
+  | "uz" /* Uzbek */
+  | "vi" /* Vietnamese */
+  | "x-pseudo" /* Pseudo */
+  | "yo" /* Yoruba Nigeria */
+  | "zh-cn" /* Chinese (China) */
+  | "zh-hk" /* Chinese (Hong Kong) */
+  | "zh-tw" /* Chinese (Taiwan) */
+  | "zh" /* Chinese */;


### PR DESCRIPTION
The generated src/locales.d.ts previously listed locale keys with no indication of which language each one maps to, so scripts/generate-locales.ts now pulls the name field from dayjs/locale.json and appends it as a trailing comment on each union member, e.g. "de" /* German */. Regenerating the file also picked up some locale reordering that had drifted between the committed file and the current dayjs/locale.json version, unrelated to the comment change itself.

Low risk since this only touches a generated .d.ts type declaration and the script that produces it, no runtime behavior changes.