### PR TITLE
fix(time): replace `any` with `unknown` for data-* index signature

### DIFF
--- a/src/Time.svelte.d.ts
+++ b/src/Time.svelte.d.ts
@@ -87,8 +87,7 @@ export interface TimeProps extends RestProps {
    */
   children?: Snippet<[string]>;
 
-  // biome-ignore lint/suspicious/noExplicitAny: data-* attributes accept any value
-  [key: `data-${string}`]: any;
+  [key: `data-${string}`]: unknown;
 }
 
 declare const Time: Component<TimeProps>;


### PR DESCRIPTION
Time.svelte.d.ts had a biome-ignore comment suppressing noExplicitAny on the data-* index signature. Duration.svelte.d.ts already types the equivalent signature as unknown with no ignore needed, so this brings Time.svelte.d.ts in line with that existing convention.

Risk is minimal since unknown still accepts any concrete value assigned to a data-* prop, it just removes the ability to read the value without narrowing first, which isn't something this index signature relies on.