### PR TITLE
feat: add Countdown component, svelteCountdown action, and countdown attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 
 ## Duration
 
-`svelte-time` also ships a `Duration` component (plus a `svelteDuration` action and a `duration` attachment) for formatting a span of time — e.g. a video length, a countdown, or a stopwatch — as opposed to `Time`, which formats a point in time.
+`svelte-time` also ships a `Duration` component (plus a `svelteDuration` action and a `duration` attachment) for formatting a span of time — e.g. a video length or a stopwatch — as opposed to `Time`, which formats a point in time. For counting down to a future instant, see the dedicated [`Countdown` component](#countdown-component).
 
 ### `Duration` component
 
@@ -821,6 +821,77 @@ The `duration` attachment is the [attachment](#time-attachment) equivalent of `s
 <time {@attach duration({ value: 3661000 })}></time>
 ```
 
+### `Countdown` component
+
+`Countdown` counts down to a future instant — the mirror image of `Duration`'s `since` stopwatch mode. Pass a `to` timestamp (a point in time that hasn't happened yet — a `Date`, ISO string, or anything dayjs accepts); the displayed value is `to - now`, clamped at zero. Unlike `Duration`, `live` defaults to `true` and ticks every second (rather than the coarser adaptive schedule used for slowly-decaying "x minutes ago" text), since a countdown's final seconds are the ones that matter most. Changing `to` to a new instant restarts the countdown.
+
+<!-- render:CountdownBasic -->
+
+```svelte
+<script>
+  import { Countdown } from "svelte-time";
+
+  let to = $state(new Date(Date.now() + 20_000));
+</script>
+
+<!-- Ticks live by default, once per second -->
+<Countdown {to} />
+
+<!-- format hides hours until they're needed -->
+<Countdown {to} format="mm:ss" />
+
+<!-- Changing `to` restarts the countdown -->
+<button onclick={() => (to = new Date(Date.now() + 20_000))}>Reset</button>
+```
+
+### `oncomplete` and the `done` flag
+
+`oncomplete` fires once, when the countdown reaches `to` (immediately, if `to` is already in the past; again, if `to` is later changed to another already-elapsed instant). The `children` snippet receives a `done` boolean alongside the formatted value, so you can swap in different markup once the countdown finishes without a separate `$effect`.
+
+<!-- render:CountdownOnComplete -->
+
+```svelte
+<script>
+  import { Countdown } from "svelte-time";
+
+  let to = $state(new Date(Date.now() + 5000));
+</script>
+
+<Countdown {to} oncomplete={() => console.log("done!")}>
+  {#snippet children(formatted, done)}
+    {done ? "Done!" : formatted}
+  {/snippet}
+</Countdown>
+```
+
+### `svelteCountdown` action
+
+An alternative to the `Countdown` component is the `svelteCountdown` action, for counting down on a raw HTML element. The API is the same as the `Countdown` component.
+
+```svelte
+<script>
+  import { svelteCountdown } from "svelte-time";
+
+  const to = new Date(Date.now() + 20_000);
+</script>
+
+<time use:svelteCountdown={{ to, oncomplete: () => console.log("done!") }}></time>
+```
+
+### `countdown` attachment
+
+The `countdown` attachment is the [attachment](#time-attachment) equivalent of `svelteCountdown`, with the same fully-reactive behavior as the `time` and `duration` attachments.
+
+```svelte
+<script>
+  import { countdown } from "svelte-time";
+
+  const to = new Date(Date.now() + 20_000);
+</script>
+
+<time {@attach countdown({ to, oncomplete: () => console.log("done!") })}></time>
+```
+
 ## Utilities
 
 The formatting logic and shared clock behind `<Time>` and `svelteTime` are also available as standalone primitives, for use outside a `<time>` element — an `aria-label`, `document.title`, a toast, server code.
@@ -892,6 +963,19 @@ The machine-readable `datetime` attribute is the accessible, parseable channel; 
 | locale     | `Locales` (TypeScript) &#124; `string`                                                                                                      | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale)) |
 | live       | `boolean` &#124; `number`                                                                                                                   | `false` (only applies when `since` is set)                                            |
 | children   | `Snippet<[string]>`                                                                                                                         | `undefined`                                                                           |
+
+### `Countdown` component props
+
+| Name       | Type                                                    | Default value                                                                         |
+| :--------- | :------------------------------------------------------ | :------------------------------------------------------------------------------------ |
+| to         | `string` &#124; `number` &#124; `Date` &#124; `Dayjs`    | (required) target instant to count down to                                            |
+| format     | `string`                                                 | `"HH:mm:ss"`                                                                          |
+| humanize   | `boolean`                                                | `false`                                                                               |
+| withSuffix | `boolean`                                                | `false` (only applies when `humanize` is `true`)                                      |
+| locale     | `Locales` (TypeScript) &#124; `string`                   | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale)) |
+| live       | `boolean` &#124; `number`                                | `true` (ticks every second; pass a number for a custom fixed interval in ms)          |
+| oncomplete | `() => void`                                             | `undefined`; fires once, when the countdown reaches `to`                              |
+| children   | `Snippet<[string, boolean]>`                             | `undefined`; receives the formatted value and a `done` flag                           |
 
 ## Examples
 

--- a/src/Countdown.svelte
+++ b/src/Countdown.svelte
@@ -1,0 +1,128 @@
+<script>
+  /** @type {import("./Countdown.svelte.d.ts").CountdownProps} */
+  const {
+    /**
+     * Target instant to count down to. Changing `to` restarts the
+     * countdown (and resets `oncomplete` to fire again once the new
+     * target is reached).
+     * @type {import("dayjs").ConfigType}
+     */
+    to,
+
+    /**
+     * Format for display, using dayjs's duration `format()` tokens
+     * (e.g. "HH:mm:ss"). Ignored when `humanize` is `true`.
+     * @type {string}
+     */
+    format = "HH:mm:ss",
+
+    /**
+     * Set to `true` to display the remaining time in a human-readable
+     * format (e.g. "an hour") instead of `format`.
+     * @type {boolean}
+     */
+    humanize = false,
+
+    /**
+     * Set to `true` to include a relative suffix in humanized output
+     * (e.g. "in an hour"). Only applies when `humanize` is `true`.
+     * @type {boolean}
+     */
+    withSuffix = false,
+
+    /**
+     * The locale to use for formatting
+     * @type {import("./locales").Locales}
+     */
+    locale = "en",
+
+    /**
+     * Set to `true` to tick every second. Pass a number (ms) to use a
+     * custom fixed interval instead. Unlike `Duration`'s `since`/`live`
+     * (tuned for slowly-decaying "x minutes ago" text), a countdown's
+     * final seconds matter most, so this is a flat interval rather than
+     * one that coarsens over time.
+     * @type {boolean | number}
+     */
+    live = true,
+
+    /**
+     * Called once, when the countdown reaches `to`.
+     * @type {(() => void) | undefined}
+     */
+    oncomplete,
+
+    /**
+     * Snippet rendered inside the `time` element instead of the plain
+     * formatted string. Receives the formatted value and whether the
+     * countdown has completed.
+     * @type {import("svelte").Snippet<[string, boolean]> | undefined}
+     */
+    children,
+    ...rest
+  } = $props();
+
+  import { dayjs } from "./dayjs";
+  import { formatDuration } from "./duration-format";
+  import { sharedNow } from "./ticker";
+
+  const canTick = typeof document !== "undefined";
+
+  // Once the countdown completes, `now` stops depending on the shared
+  // ticker (see below), which freezes `remainingMs` at 0 and lets the
+  // timer subscription tear down instead of ticking forever.
+  let completed = $state(false);
+
+  // Reset completion when `to` moves to a new instant, so a caller can
+  // restart the countdown by simply changing `to`.
+  $effect(() => {
+    to;
+    completed = false;
+  });
+
+  const effectiveInterval = $derived(
+    typeof live === "number" ? Math.abs(live) : 1000,
+  );
+
+  const now = $derived(
+    live !== false && canTick && !completed
+      ? sharedNow(effectiveInterval)
+      : dayjs(),
+  );
+
+  const remainingMs = $derived(Math.max(0, dayjs(to).diff(now)));
+
+  $effect(() => {
+    if (remainingMs === 0 && !completed) {
+      completed = true;
+      oncomplete?.();
+    }
+  });
+
+  const result = $derived.by(() =>
+    formatDuration({
+      value: remainingMs,
+      unit: "milliseconds",
+      format,
+      humanize,
+      withSuffix,
+      locale,
+    }),
+  );
+</script>
+
+{#if children}
+  <time
+    datetime={result.datetime}
+    {...rest}
+  >
+    {@render children(result.formatted, completed)}
+  </time>
+{:else}
+  <time
+    datetime={result.datetime}
+    {...rest}
+  >
+    {result.formatted}
+  </time>
+{/if}

--- a/src/Countdown.svelte.d.ts
+++ b/src/Countdown.svelte.d.ts
@@ -1,0 +1,69 @@
+import type { ConfigType } from "dayjs";
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { Locales } from "./locales";
+
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
+
+export interface CountdownProps extends RestProps {
+  /**
+   * Target instant to count down to. Changing `to` restarts the
+   * countdown (and resets `oncomplete` to fire again once the new
+   * target is reached).
+   */
+  to: ConfigType;
+
+  /**
+   * Format for display, using dayjs's duration `format()` tokens
+   * (e.g. "HH:mm:ss"). Ignored when `humanize` is `true`.
+   * @default "HH:mm:ss"
+   */
+  format?: string;
+
+  /**
+   * Set to `true` to display the remaining time in a human-readable
+   * format (e.g. "an hour") instead of `format`.
+   * @default false
+   */
+  humanize?: boolean;
+
+  /**
+   * Set to `true` to include a relative suffix in humanized output
+   * (e.g. "in an hour"). Only applies when `humanize` is `true`.
+   * @default false
+   */
+  withSuffix?: boolean;
+
+  /**
+   * The locale to use for formatting
+   * @default "en"
+   */
+  locale?: Locales;
+
+  /**
+   * Set to `true` to tick every second. Pass a number (ms) to use a
+   * custom fixed interval instead.
+   * @default true
+   */
+  live?: boolean | number;
+
+  /**
+   * Called once, when the countdown reaches `to`. Fires on mount if
+   * `to` is already in the past. Fires again if `to` is later changed
+   * to a new instant that has also already elapsed.
+   */
+  oncomplete?: () => void;
+
+  /**
+   * Snippet rendered inside the `time` element instead of the plain
+   * formatted string. Receives the formatted value and whether the
+   * countdown has completed.
+   */
+  children?: Snippet<[string, boolean]>;
+
+  [key: `data-${string}`]: unknown;
+}
+
+declare const Countdown: Component<CountdownProps>;
+
+export default Countdown;

--- a/src/attachment.d.ts
+++ b/src/attachment.d.ts
@@ -1,4 +1,5 @@
 import type { Attachment } from "svelte/attachments";
+import type { SvelteCountdownOptions } from "./svelte-countdown.svelte";
 import type { SvelteDurationOptions } from "./svelte-duration.svelte";
 import type { SvelteTimeOptions } from "./svelte-time.svelte";
 
@@ -8,4 +9,8 @@ export function time(
 
 export function duration(
   options?: Partial<SvelteDurationOptions>,
+): Attachment<HTMLElement>;
+
+export function countdown(
+  options?: Partial<SvelteCountdownOptions>,
 ): Attachment<HTMLElement>;

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -135,3 +135,55 @@ export function duration(options = {}) {
     node.textContent = result.formatted;
   };
 }
+
+/**
+ * Attachment version of `svelteCountdown`. Options are reactive: the
+ * attachment re-runs when any reactive value used to build `options`
+ * changes, and `live` mode subscribes to the shared ticker. Unlike
+ * `duration`'s `since`/`live` (tuned for slowly-decaying "x minutes
+ * ago" text), `live` here ticks every second by default, since a
+ * countdown's final seconds matter most.
+ *
+ * @param {Partial<import("./svelte-countdown.svelte").SvelteCountdownOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach countdown({ to: target, oncomplete: () => {} })}></time>
+ */
+export function countdown(options = {}) {
+  let completed = false;
+
+  return (node) => {
+    const to = options.to;
+    const format = options.format ?? "HH:mm:ss";
+    const humanize = options.humanize ?? false;
+    const withSuffix = options.withSuffix ?? false;
+    const locale = options.locale ?? "en";
+    const live = options.live ?? true;
+
+    let now = dayjs();
+    if (live !== false && !completed) {
+      // Reading sharedNow subscribes this attachment to the shared
+      // clock; each tick re-runs the whole attachment.
+      const interval = typeof live === "number" ? Math.abs(live) : 1_000;
+      now = sharedNow(interval);
+    }
+
+    const remainingMs = Math.max(0, dayjs(to).diff(now));
+
+    const result = formatDuration({
+      value: remainingMs,
+      unit: "milliseconds",
+      format,
+      humanize,
+      withSuffix,
+      locale,
+    });
+
+    node.setAttribute("datetime", result.datetime);
+    node.textContent = result.formatted;
+
+    if (remainingMs === 0 && !completed) {
+      completed = true;
+      options.oncomplete?.();
+    }
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,14 @@
-export { duration, time } from "./attachment";
+export { countdown, duration, time } from "./attachment";
+export type { CountdownProps } from "./Countdown.svelte";
+export { default as Countdown } from "./Countdown.svelte";
 export type { DurationProps } from "./Duration.svelte";
 export { default as Duration } from "./Duration.svelte";
 export { dayjs } from "./dayjs";
 export type { DayjsDuration, DurationUnit } from "./duration-format";
 export { formatTime, relativeTime } from "./format";
 export type { Locales } from "./locales";
+export type { SvelteCountdownOptions } from "./svelte-countdown.svelte";
+export { svelteCountdown } from "./svelte-countdown.svelte";
 export type { SvelteDurationOptions } from "./svelte-duration.svelte";
 export { svelteDuration } from "./svelte-duration.svelte";
 export type { SvelteTimeOptions } from "./svelte-time.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
-export { duration, time } from "./attachment";
+export { countdown, duration, time } from "./attachment";
+export { default as Countdown } from "./Countdown.svelte";
 export { default as Duration } from "./Duration.svelte";
 export { dayjs } from "./dayjs";
 export { formatTime, relativeTime } from "./format";
+export { svelteCountdown } from "./svelte-countdown.svelte";
 export { svelteDuration } from "./svelte-duration.svelte";
 export { svelteTime } from "./svelte-time.svelte";
 export { default } from "./Time.svelte";

--- a/src/svelte-countdown.svelte.d.ts
+++ b/src/svelte-countdown.svelte.d.ts
@@ -1,0 +1,19 @@
+import type { Action } from "svelte/action";
+import type { CountdownProps } from "./Countdown.svelte";
+
+export interface SvelteCountdownOptions
+  extends Pick<
+    CountdownProps,
+    | "to"
+    | "format"
+    | "humanize"
+    | "withSuffix"
+    | "locale"
+    | "live"
+    | "oncomplete"
+  > {}
+
+export const svelteCountdown: Action<
+  HTMLElement,
+  undefined | Partial<SvelteCountdownOptions>
+>;

--- a/src/svelte-countdown.svelte.js
+++ b/src/svelte-countdown.svelte.js
@@ -1,0 +1,71 @@
+import { dayjs } from "./dayjs";
+import { formatDuration } from "./duration-format";
+
+const DEFAULT_INTERVAL = 1_000;
+
+/**
+ * @typedef {import("./svelte-countdown.svelte").SvelteCountdownOptions} SvelteCountdownOptions
+ * @typedef {import ("svelte/action").Action<HTMLElement, Partial<SvelteCountdownOptions>>} SvelteCountdownAction
+ * @type {SvelteCountdownAction}
+ */
+export const svelteCountdown = (node, options = {}) => {
+  /** @type {undefined | NodeJS.Timeout} */
+  let interval;
+  let completed = false;
+
+  /** @param {Partial<SvelteCountdownOptions>} [options] */
+  const render = (options = {}) => {
+    const to = options.to;
+    const format = options.format ?? "HH:mm:ss";
+    const humanize = options.humanize ?? false;
+    const withSuffix = options.withSuffix ?? false;
+    const locale = options.locale ?? "en";
+
+    const remainingMs = Math.max(0, dayjs(to).diff(dayjs()));
+
+    const result = formatDuration({
+      value: remainingMs,
+      unit: "milliseconds",
+      format,
+      humanize,
+      withSuffix,
+      locale,
+    });
+
+    node.setAttribute("datetime", result.datetime);
+    node.textContent = result.formatted;
+
+    if (remainingMs === 0 && !completed) {
+      completed = true;
+      clearInterval(interval);
+      interval = undefined;
+      options.oncomplete?.();
+    }
+  };
+
+  /** @param {Partial<SvelteCountdownOptions>} [options] */
+  const updateCountdown = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+    completed = false;
+
+    render(options);
+
+    const live = options.live ?? true;
+    if (live !== false && !completed) {
+      interval = setInterval(
+        () => render(options),
+        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
+      );
+    }
+  };
+
+  updateCountdown(options);
+
+  return {
+    update: updateCountdown,
+    destroy() {
+      clearInterval(interval);
+    },
+  };
+};

--- a/tests/Countdown.test.svelte
+++ b/tests/Countdown.test.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { Countdown } from "svelte-time";
+
+  const { oncomplete }: { oncomplete?: () => void } = $props();
+
+  const now = new Date();
+  const fiveMinutesFromNow = new Date(now.getTime() + 5 * 60 * 1000);
+  const twoSecondsFromNow = new Date(now.getTime() + 2000);
+  const inThePast = new Date(now.getTime() - 1000);
+
+  let resetTarget = $state(inThePast);
+  let resetOncompleteCalls = $state(0);
+
+  function restart() {
+    resetTarget = new Date(Date.now() + 2000);
+  }
+</script>
+
+<!-- Basic: counts down to a future instant -->
+<Countdown
+  data-test="basic"
+  to={fiveMinutesFromNow}
+  live={false}
+/>
+
+<!-- Fixed format -->
+<Countdown
+  data-test="format-mm-ss"
+  to={fiveMinutesFromNow}
+  format="mm:ss"
+  live={false}
+/>
+
+<!-- Humanize + withSuffix -->
+<Countdown
+  data-test="humanize-default"
+  to={fiveMinutesFromNow}
+  humanize
+  live={false}
+/>
+<Countdown
+  data-test="humanize-with-suffix"
+  to={fiveMinutesFromNow}
+  humanize
+  withSuffix
+  live={false}
+/>
+
+<!-- Locale -->
+<Countdown
+  data-test="locale-de"
+  to={fiveMinutesFromNow}
+  humanize
+  locale="de"
+  live={false}
+/>
+
+<!-- Live ticking (default: every second) -->
+<Countdown
+  data-test="live"
+  to={twoSecondsFromNow}
+/>
+
+<!-- oncomplete fires once the countdown reaches zero -->
+<Countdown
+  data-test="on-complete"
+  to={twoSecondsFromNow}
+  {oncomplete}
+/>
+
+<!-- Already-past target completes immediately -->
+<Countdown
+  data-test="already-past"
+  to={inThePast}
+  live={false}
+/>
+
+<!-- children snippet receives the formatted value and the `done` flag -->
+<Countdown
+  data-test="children"
+  to={twoSecondsFromNow}
+>
+  {#snippet children(formatted, done)}
+    <span data-test="children-value">{formatted}</span>
+    <span data-test="children-done">{done}</span>
+  {/snippet}
+</Countdown>
+
+<!-- Changing `to` restarts the countdown and re-arms oncomplete -->
+<Countdown
+  data-test="reset"
+  to={resetTarget}
+  oncomplete={() => resetOncompleteCalls++}
+/>
+<span data-test="reset-oncomplete-calls">{resetOncompleteCalls}</span>
+<button
+  type="button"
+  data-test="btn-restart"
+  onclick={restart}
+>
+  Restart
+</button>

--- a/tests/Countdown.test.ts
+++ b/tests/Countdown.test.ts
@@ -1,0 +1,160 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import Countdown from "./Countdown.test.svelte";
+
+describe("Countdown", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("renders as a <time> element counting down to a future instant", () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic"]');
+    expect(el.tagName).toEqual("TIME");
+    expect(el.textContent).toEqual("00:05:00");
+    expect(el.getAttribute("datetime")).toEqual("PT5M");
+  });
+
+  test("format controls the displayed template", () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="format-mm-ss"]').textContent).toEqual(
+      "05:00",
+    );
+  });
+
+  test("humanize and withSuffix", () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="humanize-default"]').textContent).toEqual(
+      "5 minutes",
+    );
+    expect(
+      getElement('[data-test="humanize-with-suffix"]').textContent,
+    ).toEqual("in 5 minutes");
+  });
+
+  test("locale formatting", async () => {
+    await import("dayjs/locale/de");
+
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="locale-de"]').textContent).toEqual(
+      "5 Minuten",
+    );
+  });
+
+  test("live: ticks down and clamps at zero", async () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="live"]');
+    expect(el.textContent).toEqual("00:00:02");
+
+    vi.advanceTimersByTime(1000);
+    await tick();
+    expect(el.textContent).toEqual("00:00:01");
+
+    vi.advanceTimersByTime(5000);
+    await tick();
+    expect(el.textContent).toEqual("00:00:00");
+  });
+
+  test("oncomplete fires exactly once when the countdown reaches zero", async () => {
+    const oncomplete = vi.fn();
+    instance = mount(Countdown, {
+      target: document.body,
+      props: { oncomplete },
+    });
+    flushSync();
+
+    expect(oncomplete).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+    await tick();
+    expect(oncomplete).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    await tick();
+    expect(oncomplete).toHaveBeenCalledTimes(1);
+  });
+
+  test("a target already in the past renders zero immediately", () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="already-past"]').textContent).toEqual(
+      "00:00:00",
+    );
+  });
+
+  test("children snippet receives the formatted value and the done flag", async () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="children-value"]').textContent).toEqual(
+      "00:00:02",
+    );
+    expect(getElement('[data-test="children-done"]').textContent).toEqual(
+      "false",
+    );
+
+    vi.advanceTimersByTime(2000);
+    await tick();
+
+    expect(getElement('[data-test="children-value"]').textContent).toEqual(
+      "00:00:00",
+    );
+    expect(getElement('[data-test="children-done"]').textContent).toEqual(
+      "true",
+    );
+  });
+
+  test("changing `to` restarts the countdown and re-arms oncomplete", async () => {
+    instance = mount(Countdown, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="reset"]');
+    const calls = getElement('[data-test="reset-oncomplete-calls"]');
+
+    // Starts already-past -> completes immediately.
+    expect(el.textContent).toEqual("00:00:00");
+    expect(calls.textContent).toEqual("1");
+
+    const button = getElement('[data-test="btn-restart"]');
+    button.click();
+    flushSync();
+
+    expect(el.textContent).toEqual("00:00:02");
+    expect(calls.textContent).toEqual("1");
+
+    vi.advanceTimersByTime(2000);
+    await tick();
+
+    expect(el.textContent).toEqual("00:00:00");
+    expect(calls.textContent).toEqual("2");
+  });
+});

--- a/tests/CountdownAttachment.test.svelte
+++ b/tests/CountdownAttachment.test.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: `countdown` is used in the {@attach} directives below
+  import { countdown } from "svelte-time";
+
+  // biome-ignore lint/correctness/noUnusedVariables: `oncomplete` is used in the {@attach} directive below
+  const { oncomplete }: { oncomplete?: () => void } = $props();
+</script>
+
+<time
+  data-test="basic"
+  {@attach countdown({ to: new Date(Date.now() + 5 * 60 * 1000), live: false })}
+></time>
+
+<time
+  data-test="format-mm-ss"
+  {@attach countdown({
+    to: new Date(Date.now() + 5 * 60 * 1000),
+    format: "mm:ss",
+    live: false,
+  })}
+></time>
+
+<time
+  data-test="humanize"
+  {@attach countdown({
+    to: new Date(Date.now() + 5 * 60 * 1000),
+    humanize: true,
+    withSuffix: true,
+    live: false,
+  })}
+></time>
+
+<time
+  data-test="live"
+  {@attach countdown({ to: new Date(Date.now() + 2000) })}
+></time>
+
+<time
+  data-test="on-complete"
+  {@attach countdown({ to: new Date(Date.now() + 2000), oncomplete })}
+></time>

--- a/tests/CountdownAttachment.test.ts
+++ b/tests/CountdownAttachment.test.ts
@@ -1,0 +1,86 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import CountdownAttachment from "./CountdownAttachment.test.svelte";
+
+describe("countdown attachment", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("basic render: textContent and datetime are correct", () => {
+    instance = mount(CountdownAttachment, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic"]');
+    expect(el.textContent).toEqual("00:05:00");
+    expect(el.getAttribute("datetime")).toEqual("PT5M");
+  });
+
+  test("format controls the displayed template", () => {
+    instance = mount(CountdownAttachment, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="format-mm-ss"]').textContent).toEqual(
+      "05:00",
+    );
+  });
+
+  test("humanize + withSuffix", () => {
+    instance = mount(CountdownAttachment, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="humanize"]').textContent).toEqual(
+      "in 5 minutes",
+    );
+  });
+
+  test("live (default): ticks every second via the shared clock", async () => {
+    instance = mount(CountdownAttachment, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="live"]');
+    expect(el.textContent).toEqual("00:00:02");
+
+    vi.advanceTimersByTime(1000);
+    await tick();
+
+    expect(el.textContent).toEqual("00:00:01");
+  });
+
+  test("oncomplete fires exactly once when the countdown reaches zero", async () => {
+    const oncomplete = vi.fn();
+    instance = mount(CountdownAttachment, {
+      target: document.body,
+      props: { oncomplete },
+    });
+    flushSync();
+
+    expect(oncomplete).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+    await tick();
+    expect(oncomplete).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    await tick();
+    expect(oncomplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/SvelteCountdownAction.test.svelte
+++ b/tests/SvelteCountdownAction.test.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { svelteCountdown } from "svelte-time";
+
+  const now = new Date();
+  const fiveMinutesFromNow = new Date(now.getTime() + 5 * 60 * 1000);
+  const twoSecondsFromNow = new Date(now.getTime() + 2000);
+
+  const { oncomplete }: { oncomplete?: () => void } = $props();
+</script>
+
+<time
+  data-test="basic"
+  use:svelteCountdown={{ to: fiveMinutesFromNow, live: false }}
+></time>
+<span
+  data-test="basic-span"
+  use:svelteCountdown={{ to: fiveMinutesFromNow, live: false }}
+></span>
+
+<time
+  data-test="format-mm-ss"
+  use:svelteCountdown={{
+    to: fiveMinutesFromNow,
+    format: "mm:ss",
+    live: false,
+  }}
+></time>
+
+<time
+  data-test="humanize"
+  use:svelteCountdown={{
+    to: fiveMinutesFromNow,
+    humanize: true,
+    withSuffix: true,
+    live: false,
+  }}
+></time>
+
+<time
+  data-test="locale"
+  use:svelteCountdown={{
+    to: fiveMinutesFromNow,
+    humanize: true,
+    locale: "de",
+    live: false,
+  }}
+></time>
+
+<time
+  data-test="live"
+  use:svelteCountdown={{ to: twoSecondsFromNow }}
+></time>
+
+<time
+  data-test="on-complete"
+  use:svelteCountdown={{ to: twoSecondsFromNow, oncomplete }}
+></time>

--- a/tests/SvelteCountdownAction.test.ts
+++ b/tests/SvelteCountdownAction.test.ts
@@ -1,0 +1,108 @@
+import { flushSync, mount, tick, unmount } from "svelte";
+import SvelteCountdownAction from "./SvelteCountdownAction.test.svelte";
+
+describe("svelteCountdown action", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("sets datetime and text on a <time> element", () => {
+    instance = mount(SvelteCountdownAction, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic"]');
+    expect(el.tagName).toEqual("TIME");
+    expect(el.textContent).toEqual("00:05:00");
+    expect(el.getAttribute("datetime")).toEqual("PT5M");
+  });
+
+  test("works on non-time elements too", () => {
+    instance = mount(SvelteCountdownAction, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="basic-span"]');
+    expect(el.tagName).toEqual("SPAN");
+    expect(el.textContent).toEqual("00:05:00");
+  });
+
+  test("format controls the displayed template", () => {
+    instance = mount(SvelteCountdownAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="format-mm-ss"]').textContent).toEqual(
+      "05:00",
+    );
+  });
+
+  test("humanize + withSuffix", () => {
+    instance = mount(SvelteCountdownAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="humanize"]').textContent).toEqual(
+      "in 5 minutes",
+    );
+  });
+
+  test("locale", async () => {
+    await import("dayjs/locale/de");
+
+    instance = mount(SvelteCountdownAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="locale"]').textContent).toEqual("5 Minuten");
+  });
+
+  test("live (default): ticks every second and clamps at zero", async () => {
+    instance = mount(SvelteCountdownAction, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="live"]');
+    expect(el.textContent).toEqual("00:00:02");
+
+    vi.advanceTimersByTime(1000);
+    await tick();
+    expect(el.textContent).toEqual("00:00:01");
+
+    vi.advanceTimersByTime(5000);
+    await tick();
+    expect(el.textContent).toEqual("00:00:00");
+  });
+
+  test("oncomplete fires exactly once when the countdown reaches zero", async () => {
+    const oncomplete = vi.fn();
+    instance = mount(SvelteCountdownAction, {
+      target: document.body,
+      props: { oncomplete },
+    });
+    flushSync();
+
+    expect(oncomplete).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+    await tick();
+    expect(oncomplete).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(10_000);
+    await tick();
+    expect(oncomplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/examples/CountdownBasic.svelte
+++ b/tests/examples/CountdownBasic.svelte
@@ -1,0 +1,33 @@
+<script>
+  import { Countdown } from "svelte-time";
+
+  const SECONDS = 20;
+
+  let toDefault = $state(new Date(Date.now() + SECONDS * 1000));
+  let toFormatted = $state(new Date(Date.now() + SECONDS * 1000));
+</script>
+
+<div>
+  <!-- Ticks live by default, once per second -->
+  <Countdown to={toDefault} />
+  <button
+    type="button"
+    onclick={() => (toDefault = new Date(Date.now() + SECONDS * 1000))}
+  >
+    Reset
+  </button>
+</div>
+
+<div>
+  <!-- format hides hours until they're needed -->
+  <Countdown
+    to={toFormatted}
+    format="mm:ss"
+  />
+  <button
+    type="button"
+    onclick={() => (toFormatted = new Date(Date.now() + SECONDS * 1000))}
+  >
+    Reset
+  </button>
+</div>

--- a/tests/examples/CountdownOnComplete.svelte
+++ b/tests/examples/CountdownOnComplete.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { Countdown } from "svelte-time";
+
+  const SECONDS = 5;
+
+  let to = $state(new Date(Date.now() + SECONDS * 1000));
+  let completedCount = $state(0);
+
+  function reset() {
+    to = new Date(Date.now() + SECONDS * 1000);
+  }
+</script>
+
+<Countdown
+  {to}
+  oncomplete={() => completedCount++}
+>
+  {#snippet children(formatted, done)}
+    {done ? "Done!" : formatted}
+  {/snippet}
+</Countdown>
+
+<p>oncomplete fired: {completedCount} time(s)</p>
+<button
+  type="button"
+  onclick={reset}
+>
+  Reset
+</button>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,13 +2,16 @@ import * as API from "svelte-time";
 
 test("Library has exports", () => {
   expect(Object.keys(API).sort()).toEqual([
+    "Countdown",
     "Duration",
+    "countdown",
     "dayjs",
     "default",
     "duration",
     "formatTime",
     "now",
     "relativeTime",
+    "svelteCountdown",
     "svelteDuration",
     "svelteTime",
     "time",

--- a/tests/ssr/Countdown.ssr.test.ts
+++ b/tests/ssr/Countdown.ssr.test.ts
@@ -1,0 +1,54 @@
+import { render } from "svelte/server";
+import { Countdown } from "svelte-time";
+import CountdownAttachment from "../CountdownAttachment.test.svelte";
+
+describe("Countdown (SSR)", () => {
+  const TS = "2024-01-01T00:00:00.000Z";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(TS));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders a populated <time> element on the server", () => {
+    const to = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+    const { body } = render(Countdown, { props: { to, live: false } });
+    expect(body).toContain("<time");
+    expect(body).toContain("00:05:00");
+    expect(body).toContain('datetime="PT5M"');
+  });
+
+  test("humanize renders on the server", () => {
+    const to = new Date(Date.now() + 3600000).toISOString();
+    const { body } = render(Countdown, {
+      props: { to, humanize: true, live: false },
+    });
+    expect(body).toContain("an hour");
+  });
+
+  test("default live mode starts no timers on the server", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    render(Countdown, { props: { to: new Date().toISOString() } });
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe("countdown attachment (SSR)", () => {
+  test("attachments do not run during server rendering", () => {
+    const { body } = render(CountdownAttachment);
+    expect(body).toContain('<time data-test="basic"></time>');
+    expect(body).not.toContain("datetime=");
+  });
+
+  test("default live mode starts no timers on the server", () => {
+    const spy = vi.spyOn(global, "setInterval");
+    render(CountdownAttachment);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
Adds a Countdown component as the counterpart to Duration's since/live stopwatch mode. It takes a to prop (a future instant) and displays the remaining time, clamped at zero, ticking every second by default rather than on Duration's coarser adaptive schedule, since a countdown's final seconds are what matter most. Changing to restarts the countdown. An oncomplete callback fires once when the countdown reaches zero, and the children snippet receives a done flag so callers can swap in different markup without a separate effect.

Also adds svelteCountdown (an action) and countdown (an attachment) so the same behavior is available on a raw element, matching the existing pattern for Duration/svelteDuration/duration. All three share the formatDuration formatting logic already used by Duration.

Risk is low since this is purely additive: no existing exports, props, or behavior changed. The one thing to watch is the reset-on-to-change behavior in the component, since completed state needs to clear correctly whenever to moves to a new instant, otherwise a countdown reused with a new target could get stuck showing zero. That path has direct test coverage. Test suite, svelte-check, biome, and the docs build all pass.