### PR TITLE
feat: add `TimeRange` component, `svelteTimeRange` action, and `timeRange` attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ dayjs().local().format("zzz"); // Eastern Standard Time
 
 ## Duration
 
-`svelte-time` also ships a `Duration` component (plus a `svelteDuration` action and a `duration` attachment) for formatting a span of time — e.g. a video length or a stopwatch — as opposed to `Time`, which formats a point in time. For counting up from an instant with built-in pause/resume, see the dedicated [`Stopwatch` component](#stopwatch-component); for counting down to a future instant, see the dedicated [`Countdown` component](#countdown-component).
+`svelte-time` also ships a `Duration` component (plus a `svelteDuration` action and a `duration` attachment) for formatting a span of time — e.g. a video length or a stopwatch — as opposed to `Time`, which formats a point in time. For counting up from an instant with built-in pause/resume, see the dedicated [`Stopwatch` component](#stopwatch-component); for counting down to a future instant, see the dedicated [`Countdown` component](#countdown-component). For a span between two fixed endpoints — e.g. an event's start/end — see the dedicated [`TimeRange` component](#timerange-component).
 
 ### `Duration` component
 
@@ -966,6 +966,125 @@ The `countdown` attachment is the [attachment](#time-attachment) equivalent of `
 <time {@attach countdown({ to, oncomplete: () => console.log("done!") })}></time>
 ```
 
+## Time Range
+
+`TimeRange` formats a span between two fixed instants — an event's start/end, a meeting window — as opposed to `Duration`, whose endpoints are open-ended. HTML's `datetime` attribute can only hold a single machine-readable value, so it can't represent a range: `TimeRange` renders **two** `<time>` elements, one per endpoint, each with its own correct `datetime`, joined by a separator.
+
+### `TimeRange` component
+
+`format` (dayjs `.format()` tokens, same default as `Time`) applies independently to `start` and `end` — this is a v1 simplification, not a "smart" range formatter that dedupes a shared year/month (see [API](#api) for the full props list).
+
+<!-- render:TimeRangeBasic -->
+
+```svelte
+<script>
+  import { TimeRange } from "svelte-time";
+</script>
+
+<!-- An event's start/end -->
+<TimeRange
+  start="2024-06-05"
+  end="2024-06-10"
+/>
+<!-- Output: "Jun 05, 2024 – Jun 10, 2024" -->
+```
+
+For a "live"/relative range (e.g. "3 days" as the humanized span between the endpoints), compose `Duration` instead:
+
+```svelte
+<Duration value={dayjs(end).diff(start)} humanize />
+```
+
+### Meeting window
+
+`format` isn't limited to dates — pass a time-only format (and a custom `separator`) for a same-day window.
+
+<!-- render:TimeRangeMeeting -->
+
+```svelte
+<script>
+  import { TimeRange } from "svelte-time";
+</script>
+
+<!-- A same-day meeting window -->
+<TimeRange
+  start="2024-06-05T08:00:00"
+  end="2024-06-05T10:00:00"
+  format="h:mm A"
+/>
+<!-- Output: "8:00 AM – 10:00 AM" -->
+```
+
+### Locale
+
+Use the `locale` prop to format both endpoints in different languages. Make sure to import the locale from `dayjs` first.
+
+<!-- render:TimeRangeLocale -->
+
+```svelte
+<script>
+  import "dayjs/locale/de";
+  import { TimeRange } from "svelte-time";
+</script>
+
+<TimeRange
+  start="2024-06-05"
+  end="2024-06-10"
+  format="D. MMMM"
+  locale="de"
+/>
+<!-- Output: "5. Juni – 10. Juni" -->
+```
+
+### Custom markup
+
+Pass a `children` snippet to fully replace the default output — unlike `Time`/`Duration`'s `children`, which only swaps the inner text of a single element, `TimeRange`'s snippet owns both `<time>` elements and the separator, since `format` alone can't express a "condensed" range (e.g. a shared date shown once, with only the time repeated on each side). Format each side independently with `dayjs` inside the snippet to get that.
+
+<!-- render:TimeRangeCustomMarkup -->
+
+```svelte
+<script>
+  import { dayjs, TimeRange } from "svelte-time";
+
+  const start = "2024-06-05T08:00:00";
+  const end = "2024-06-05T10:00:00";
+</script>
+
+<!-- Condensed: date once, time on each side -->
+<TimeRange {start} {end}>
+  {#snippet children({ startDatetime, endDatetime })}
+    <time datetime={startDatetime}>{dayjs(start).format("MMM D, h:mm A")}</time>
+    –
+    <time datetime={endDatetime}>{dayjs(end).format("h:mm A")}</time>
+  {/snippet}
+</TimeRange>
+<!-- Output: "Jun 5, 8:00 AM – 10:00 AM" -->
+```
+
+### `svelteTimeRange` action
+
+An alternative to the `TimeRange` component is the `svelteTimeRange` action. Since an action attaches to a single DOM node but a range needs two `<time>` elements, `svelteTimeRange` is used on a wrapper element, which it populates with the two `<time>` children and the separator.
+
+```svelte
+<script>
+  import { svelteTimeRange } from "svelte-time";
+</script>
+
+<span use:svelteTimeRange={{ start: "2024-06-05", end: "2024-06-10" }}></span>
+```
+
+### `timeRange` attachment
+
+The `timeRange` attachment is the [attachment](#time-attachment) equivalent of `svelteTimeRange`, with the same reactive options, used on a wrapper element in the same way.
+
+```svelte
+<script>
+  import { timeRange } from "svelte-time";
+</script>
+
+<span {@attach timeRange({ start: "2024-06-05", end: "2024-06-10" })}></span>
+```
+
 ## Utilities
 
 The formatting logic and shared clock behind `<Time>` and `svelteTime` are also available as standalone primitives, for use outside a `<time>` element — an `aria-label`, `document.title`, a toast, server code.
@@ -1063,6 +1182,20 @@ The machine-readable `datetime` attribute is the accessible, parseable channel; 
 | live       | `boolean` &#124; `number`                                | `true` (ticks every second; pass a number for a custom fixed interval in ms)          |
 | oncomplete | `() => void`                                             | `undefined`; fires once, when the countdown reaches `to`                              |
 | children   | `Snippet<[string, boolean]>`                             | `undefined`; receives the formatted value and a `done` flag                           |
+
+### `TimeRange` component props
+
+| Name      | Type                                                   | Default value                                                                                                                                     |
+| :-------- | :------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
+| start     | `string` &#124; `number` &#124; `Date` &#124; `Dayjs`   | (required) start instant                                                                                                                              |
+| end       | `string` &#124; `number` &#124; `Date` &#124; `Dayjs`   | (required) end instant                                                                                                                                |
+| format    | `string`                                                 | `"MMM DD, YYYY"` (applied independently to `start` and `end`)                                                                                         |
+| separator | `string`                                                 | `" – "`                                                                                                                                                |
+| locale    | `Locales` (TypeScript) &#124; `string`                  | `"en"` (See [supported locales](https://github.com/iamkun/dayjs/tree/dev/src/locale))                                                                 |
+| tz        | `string`                                                 | `undefined` (applied to both `start` and `end`; requires the dayjs `utc`/`timezone` plugins. See [tz prop](#tz-prop))                                 |
+| children  | `Snippet<[object]>`                                      | `undefined`; receives a single object with `formattedStart`, `formattedEnd`, `startDatetime`, and `endDatetime` fields — destructure only what you need — and replaces the entire default output, not just the inner text   |
+
+The `...rest` props (`SvelteHTMLElements["time"]` minus `children`) are spread onto **both** `<time>` elements — there's no per-side rest-prop split in v1.
 
 ## Examples
 

--- a/src/TimeRange.svelte
+++ b/src/TimeRange.svelte
@@ -1,0 +1,105 @@
+<script>
+  /** @type {import("./TimeRange.svelte.d.ts").TimeRangeProps} */
+  const {
+    /**
+     * Start instant of the range.
+     * @type {import("dayjs").ConfigType}
+     */
+    start,
+
+    /**
+     * End instant of the range.
+     * @type {import("dayjs").ConfigType}
+     */
+    end,
+
+    /**
+     * Format applied independently to `start` and `end`.
+     * @type {string}
+     * @example "YYYY-MM-DD"
+     */
+    format = "MMM DD, YYYY",
+
+    /**
+     * Text rendered between the two formatted instants.
+     * @type {string}
+     */
+    separator = " – ",
+
+    /**
+     * The locale to use for formatting
+     * @type {import("./locales").Locales}
+     */
+    locale = "en",
+
+    /**
+     * IANA timezone name (e.g. "America/New_York") applied to both
+     * `start` and `end`. Requires the dayjs `utc` and `timezone` plugins
+     * to be extended.
+     * @type {string | undefined}
+     */
+    tz = undefined,
+
+    /**
+     * Snippet replacing the entire default output (both `time` elements
+     * and the separator). Receives a single object — destructure only
+     * the fields you need — with `formattedStart`, `formattedEnd`,
+     * `startDatetime`, and `endDatetime`.
+     * @type {import("svelte").Snippet<[{ formattedStart: string, formattedEnd: string, startDatetime: string, endDatetime: string }]> | undefined}
+     */
+    children,
+    ...rest
+  } = $props();
+
+  import { toDatetime } from "./datetime";
+  import { dayjs } from "./dayjs";
+  import { resolveLocale } from "./format";
+
+  const effectiveLocale = $derived(resolveLocale(start, locale));
+
+  /**
+   * Parse an instant with the timezone (if provided) and effective
+   * locale applied.
+   * @param {import("dayjs").ConfigType} value
+   * @returns {import("dayjs").Dayjs}
+   */
+  const getDay = (value) => {
+    const base = dayjs(value);
+    if (tz === undefined) return base.locale(effectiveLocale);
+    if (typeof base.tz !== "function") {
+      throw new Error(
+        "svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins — " +
+          "see https://github.com/metonym/svelte-time#custom-timezone",
+      );
+    }
+    return base.tz(tz).locale(effectiveLocale);
+  };
+
+  const startDay = $derived(getDay(start));
+  const endDay = $derived(getDay(end));
+
+  const formattedStart = $derived(startDay.format(format));
+  const formattedEnd = $derived(endDay.format(format));
+
+  const startDatetime = $derived(toDatetime(start));
+  const endDatetime = $derived(toDatetime(end));
+
+  // Combined into a single spread per <time> element (rather than
+  // `{...rest} datetime={...}`) so the formatter keeps each element on
+  // one line — a line break between the separator and the second
+  // <time> would otherwise be read as a literal space in the output.
+  const startAttrs = $derived({ ...rest, datetime: startDatetime });
+  const endAttrs = $derived({ ...rest, datetime: endDatetime });
+</script>
+
+{#if children}
+  {@render children({
+    formattedStart,
+    formattedEnd,
+    startDatetime: startDatetime ?? "",
+    endDatetime: endDatetime ?? "",
+  })}
+{:else}
+  <time {...startAttrs}>{formattedStart}</time>{separator}<!--
+  --><time {...endAttrs}>{formattedEnd}</time>
+{/if}

--- a/src/TimeRange.svelte.d.ts
+++ b/src/TimeRange.svelte.d.ts
@@ -1,0 +1,70 @@
+import type { ConfigType } from "dayjs";
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { Locales } from "./locales";
+
+export interface TimeRangeProps
+  extends Omit<SvelteHTMLElements["time"], "children"> {
+  /**
+   * Start instant of the range.
+   */
+  start: ConfigType;
+
+  /**
+   * End instant of the range.
+   */
+  end: ConfigType;
+
+  /**
+   * Format applied independently to `start` and `end`.
+   * @default "MMM DD, YYYY"
+   */
+  format?: string;
+
+  /**
+   * Text rendered between the two formatted instants.
+   * @default " – "
+   */
+  separator?: string;
+
+  /**
+   * The locale to use for formatting
+   * @default "en"
+   */
+  locale?: Locales;
+
+  /**
+   * IANA timezone name (e.g. "America/New_York") applied to both
+   * `start` and `end`. Requires the dayjs `utc` and `timezone` plugins
+   * to be extended by the consumer — throws at runtime otherwise.
+   * @default undefined
+   */
+  tz?: string;
+
+  /**
+   * Snippet replacing the entire default output (both `time` elements
+   * and the separator) — unlike `Time`/`Duration`'s `children`, this
+   * doesn't just replace the inner text of a single element, since
+   * there are two elements and a separator to arrange. Receives a
+   * single object so callers can destructure only what they need
+   * (e.g. just `startDatetime`/`endDatetime` when re-formatting both
+   * sides independently) instead of naming every earlier positional
+   * argument.
+   */
+  children?: Snippet<
+    [
+      {
+        formattedStart: string;
+        formattedEnd: string;
+        startDatetime: string;
+        endDatetime: string;
+      },
+    ]
+  >;
+
+  [key: `data-${string}`]: unknown;
+}
+
+declare const TimeRange: Component<TimeRangeProps>;
+
+export default TimeRange;

--- a/src/attachment.d.ts
+++ b/src/attachment.d.ts
@@ -3,6 +3,7 @@ import type { SvelteCountdownOptions } from "./svelte-countdown.svelte";
 import type { SvelteDurationOptions } from "./svelte-duration.svelte";
 import type { SvelteStopwatchOptions } from "./svelte-stopwatch.svelte";
 import type { SvelteTimeOptions } from "./svelte-time.svelte";
+import type { SvelteTimeRangeOptions } from "./svelte-time-range.svelte";
 
 export function time(
   options?: Partial<SvelteTimeOptions>,
@@ -18,4 +19,8 @@ export function countdown(
 
 export function stopwatch(
   options?: Partial<SvelteStopwatchOptions>,
+): Attachment<HTMLElement>;
+
+export function timeRange(
+  options?: Partial<SvelteTimeRangeOptions>,
 ): Attachment<HTMLElement>;

--- a/src/attachment.js
+++ b/src/attachment.js
@@ -287,3 +287,54 @@ export function stopwatch(options = {}) {
     node.textContent = result.formatted;
   };
 }
+
+/**
+ * Attachment version of `svelteTimeRange`. Options are reactive: the
+ * attachment re-runs when any reactive value used to build `options`
+ * changes. Since the target node needs two `<time>` elements (a range
+ * has two endpoints), each run rebuilds them from scratch and replaces
+ * the node's children, rather than mutating a single node in place.
+ *
+ * @param {Partial<import("./svelte-time-range.svelte").SvelteTimeRangeOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <span {@attach timeRange({ start, end })}></span>
+ */
+export function timeRange(options = {}) {
+  return (node) => {
+    const format = options.format || "MMM DD, YYYY";
+    const separator = options.separator ?? " – ";
+    const tz = options.tz;
+    const locale = resolveLocale(options.start, options.locale);
+
+    const getDay = (/** @type {import("dayjs").ConfigType} */ value) => {
+      const base = dayjs(value);
+      if (tz !== undefined && typeof base.tz !== "function") {
+        throw new Error(
+          "svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins — " +
+            "see https://github.com/metonym/svelte-time#custom-timezone",
+        );
+      }
+      return (tz === undefined ? base : base.tz(tz)).locale(locale);
+    };
+
+    const startTime = document.createElement("time");
+    const startDatetime = toDatetime(options.start);
+    if (startDatetime !== undefined) {
+      startTime.setAttribute("datetime", startDatetime);
+    }
+    startTime.textContent = getDay(options.start).format(format);
+
+    const endTime = document.createElement("time");
+    const endDatetime = toDatetime(options.end);
+    if (endDatetime !== undefined) {
+      endTime.setAttribute("datetime", endDatetime);
+    }
+    endTime.textContent = getDay(options.end).format(format);
+
+    node.replaceChildren(
+      startTime,
+      document.createTextNode(separator),
+      endTime,
+    );
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-export { countdown, duration, stopwatch, time } from "./attachment";
+export { countdown, duration, stopwatch, time, timeRange } from "./attachment";
 export type { CountdownProps } from "./Countdown.svelte";
 export { default as Countdown } from "./Countdown.svelte";
 export type { DurationProps } from "./Duration.svelte";
@@ -17,6 +17,10 @@ export type { SvelteStopwatchOptions } from "./svelte-stopwatch.svelte";
 export { svelteStopwatch } from "./svelte-stopwatch.svelte";
 export type { SvelteTimeOptions } from "./svelte-time.svelte";
 export { svelteTime } from "./svelte-time.svelte";
+export type { SvelteTimeRangeOptions } from "./svelte-time-range.svelte";
+export { svelteTimeRange } from "./svelte-time-range.svelte";
 export type { RelativeStyle, TimeProps } from "./Time.svelte";
 export { default } from "./Time.svelte";
+export type { TimeRangeProps } from "./TimeRange.svelte";
+export { default as TimeRange } from "./TimeRange.svelte";
 export { now } from "./ticker";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { countdown, duration, stopwatch, time } from "./attachment";
+export { countdown, duration, stopwatch, time, timeRange } from "./attachment";
 export { default as Countdown } from "./Countdown.svelte";
 export { default as Duration } from "./Duration.svelte";
 export { dayjs } from "./dayjs";
@@ -8,5 +8,7 @@ export { svelteCountdown } from "./svelte-countdown.svelte";
 export { svelteDuration } from "./svelte-duration.svelte";
 export { svelteStopwatch } from "./svelte-stopwatch.svelte";
 export { svelteTime } from "./svelte-time.svelte";
+export { svelteTimeRange } from "./svelte-time-range.svelte";
 export { default } from "./Time.svelte";
+export { default as TimeRange } from "./TimeRange.svelte";
 export { now } from "./ticker";

--- a/src/svelte-time-range.svelte.d.ts
+++ b/src/svelte-time-range.svelte.d.ts
@@ -1,0 +1,13 @@
+import type { Action } from "svelte/action";
+import type { TimeRangeProps } from "./TimeRange.svelte";
+
+export interface SvelteTimeRangeOptions
+  extends Pick<
+    TimeRangeProps,
+    "start" | "end" | "format" | "separator" | "locale" | "tz"
+  > {}
+
+export const svelteTimeRange: Action<
+  HTMLElement,
+  undefined | Partial<SvelteTimeRangeOptions>
+>;

--- a/src/svelte-time-range.svelte.js
+++ b/src/svelte-time-range.svelte.js
@@ -1,0 +1,63 @@
+import { toDatetime } from "./datetime";
+import { dayjs } from "./dayjs";
+import { resolveLocale } from "./format";
+
+/**
+ * @typedef {import("./svelte-time-range.svelte").SvelteTimeRangeOptions} SvelteTimeRangeOptions
+ * @typedef {import ("svelte/action").Action<HTMLElement, Partial<SvelteTimeRangeOptions>>} SvelteTimeRangeAction
+ * @type {SvelteTimeRangeAction}
+ */
+export const svelteTimeRange = (node, options = {}) => {
+  // An action attaches to a single node, but a range needs two <time>
+  // elements — build them once here and mutate their attributes/text
+  // on every update, mirroring how `svelteTime` mutates a single node.
+  const startTime = document.createElement("time");
+  const separatorText = document.createTextNode("");
+  const endTime = document.createElement("time");
+  node.replaceChildren(startTime, separatorText, endTime);
+
+  /** @param {import("dayjs").Dayjs} base */
+  const requireTz = (base) => {
+    if (typeof base.tz === "function") return;
+    throw new Error(
+      "svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins — " +
+        "see https://github.com/metonym/svelte-time#custom-timezone",
+    );
+  };
+
+  /** @param {Partial<SvelteTimeRangeOptions>} [options] */
+  const updateTimeRange = (options = {}) => {
+    const format = options.format || "MMM DD, YYYY";
+    const separator = options.separator ?? " – ";
+    const tz = options.tz;
+    const locale = resolveLocale(options.start, options.locale);
+
+    /** @param {import("dayjs").ConfigType} value */
+    const getDay = (value) => {
+      const base = dayjs(value);
+      if (tz === undefined) return base.locale(locale);
+      requireTz(base);
+      return base.tz(tz).locale(locale);
+    };
+
+    const startDay = getDay(options.start);
+    const startDatetime = toDatetime(options.start);
+    if (startDatetime === undefined) startTime.removeAttribute("datetime");
+    else startTime.setAttribute("datetime", startDatetime);
+    startTime.textContent = startDay.format(format);
+
+    const endDay = getDay(options.end);
+    const endDatetime = toDatetime(options.end);
+    if (endDatetime === undefined) endTime.removeAttribute("datetime");
+    else endTime.setAttribute("datetime", endDatetime);
+    endTime.textContent = endDay.format(format);
+
+    separatorText.textContent = separator;
+  };
+
+  updateTimeRange(options);
+
+  return {
+    update: updateTimeRange,
+  };
+};

--- a/tests/SvelteTimeRangeAction.test.svelte
+++ b/tests/SvelteTimeRangeAction.test.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { svelteTimeRange } from "svelte-time";
+
+  let start = $state("2024-01-05");
+  let end = $state("2024-01-10T00:00:00.000Z");
+</script>
+
+<span
+  data-test="basic"
+  use:svelteTimeRange={{ start, end }}
+></span>
+
+<span
+  data-test="format"
+  use:svelteTimeRange={{ start, end, format: "YYYY-MM-DD" }}
+></span>
+
+<span
+  data-test="separator"
+  use:svelteTimeRange={{ start, end, separator: " to " }}
+></span>
+
+<span
+  data-test="locale"
+  use:svelteTimeRange={{ start, end, format: "MMMM", locale: "de" }}
+></span>
+
+<button
+  type="button"
+  onclick={() => {
+    start = "2024-02-05";
+    end = "2024-02-10T00:00:00.000Z";
+  }}
+>
+  Update
+</button>

--- a/tests/SvelteTimeRangeAction.test.ts
+++ b/tests/SvelteTimeRangeAction.test.ts
@@ -1,0 +1,136 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import { svelteTimeRange } from "../src/svelte-time-range.svelte.js";
+import SvelteTimeRangeAction from "./SvelteTimeRangeAction.test.svelte";
+
+describe("svelteTimeRange action", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+
+  const START = "2024-01-05";
+  const END = "2024-01-10T00:00:00.000Z";
+
+  afterEach(() => {
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("builds two <time> children with the correct datetime and text", () => {
+    instance = mount(SvelteTimeRangeAction, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="basic"]').querySelectorAll("time");
+    expect(times.length).toEqual(2);
+    expect(times[0]!.getAttribute("datetime")).toEqual(START);
+    expect(times[0]!.textContent).toEqual(dayjs(START).format("MMM DD, YYYY"));
+    expect(times[1]!.getAttribute("datetime")).toEqual(END);
+    expect(times[1]!.textContent).toEqual(dayjs(END).format("MMM DD, YYYY"));
+    expect(getElement('[data-test="basic"]').textContent).toEqual(
+      `${dayjs(START).format("MMM DD, YYYY")} – ${dayjs(END).format("MMM DD, YYYY")}`,
+    );
+  });
+
+  test("format controls the displayed template on both endpoints", () => {
+    instance = mount(SvelteTimeRangeAction, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="format"]').querySelectorAll("time");
+    expect(times[0]!.textContent).toEqual("2024-01-05");
+    expect(times[1]!.textContent).toEqual(dayjs(END).format("YYYY-MM-DD"));
+  });
+
+  test("separator is rendered between the two <time> elements", () => {
+    instance = mount(SvelteTimeRangeAction, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="separator"]').textContent).toEqual(
+      `${dayjs(START).format("MMM DD, YYYY")} to ${dayjs(END).format("MMM DD, YYYY")}`,
+    );
+  });
+
+  test("locale applies to both endpoints", () => {
+    instance = mount(SvelteTimeRangeAction, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="locale"]').querySelectorAll("time");
+    expect(times[0]!.textContent).toEqual(
+      dayjs(START).locale("de").format("MMMM"),
+    );
+    expect(times[1]!.textContent).toEqual(
+      dayjs(END).locale("de").format("MMMM"),
+    );
+  });
+
+  test("updates both endpoints when the options change (reactivity)", () => {
+    instance = mount(SvelteTimeRangeAction, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="basic"]').querySelectorAll("time");
+    expect(times[0]!.getAttribute("datetime")).toEqual(START);
+
+    getElement("button").click();
+    flushSync();
+
+    const updatedTimes = getElement('[data-test="basic"]').querySelectorAll(
+      "time",
+    );
+    expect(updatedTimes[0]!.getAttribute("datetime")).toEqual("2024-02-05");
+    expect(updatedTimes[0]!.textContent).toEqual(
+      dayjs("2024-02-05").format("MMM DD, YYYY"),
+    );
+    expect(updatedTimes[1]!.getAttribute("datetime")).toEqual(
+      "2024-02-10T00:00:00.000Z",
+    );
+  });
+
+  test("works on a non-time wrapper element", () => {
+    const node = document.createElement("div");
+    document.body.appendChild(node);
+    const handle = svelteTimeRange(node, { start: START, end: END });
+    expect(node.querySelectorAll("time").length).toEqual(2);
+    handle?.update?.({ start: START, end: END });
+    expect(node.querySelectorAll("time").length).toEqual(2);
+  });
+});
+
+// Isolated: dayjs plugin extension mutates the shared `dayjs` singleton for
+// the lifetime of the Vitest worker. See TimezoneMissingPlugin.test.ts.
+describe("svelteTimeRange tz option without utc/timezone plugins extended", () => {
+  test("throws a clear, actionable error", async () => {
+    vi.resetModules();
+
+    const { dayjs } = await import("../src/dayjs.js");
+    expect(typeof (dayjs() as any).tz).not.toEqual("function");
+
+    const { svelteTimeRange } = await import(
+      "../src/svelte-time-range.svelte.js"
+    );
+
+    const node = document.createElement("span");
+    document.body.appendChild(node);
+
+    let thrown: unknown;
+    try {
+      svelteTimeRange(node, {
+        start: "2013-11-18T11:55:20Z",
+        end: "2013-11-19T11:55:20Z",
+        tz: "America/Toronto",
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      document.body.innerHTML = "";
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(
+      /svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins/,
+    );
+  }, 15_000);
+});

--- a/tests/TimeRange.test.svelte
+++ b/tests/TimeRange.test.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { TimeRange } from "svelte-time";
+
+  const START = "2024-01-05";
+  const END = "2024-01-10T00:00:00.000Z";
+</script>
+
+<span data-test="default">
+  <TimeRange
+    start={START}
+    end={END}
+  />
+</span>
+
+<span data-test="custom-format">
+  <TimeRange
+    start={START}
+    end={END}
+    format="YYYY-MM-DD"
+  />
+</span>
+
+<span data-test="custom-separator">
+  <TimeRange
+    start={START}
+    end={END}
+    separator=" to "
+  />
+</span>
+
+<span data-test="locale">
+  <TimeRange
+    start={START}
+    end={END}
+    format="MMMM"
+    locale="de"
+  />
+</span>
+
+<span data-test="rest-props">
+  <TimeRange
+    start={START}
+    end={END}
+    class="range"
+    data-foo="bar"
+  />
+</span>
+
+<span data-test="children">
+  <TimeRange
+    start={START}
+    end={END}
+  >
+    {#snippet children({ formattedStart, formattedEnd, startDatetime, endDatetime })}
+      <div data-test="children-start">{formattedStart}</div>
+      <div data-test="children-end">{formattedEnd}</div>
+      <div data-test="children-start-datetime">{startDatetime}</div>
+      <div data-test="children-end-datetime">{endDatetime}</div>
+    {/snippet}
+  </TimeRange>
+</span>

--- a/tests/TimeRange.test.ts
+++ b/tests/TimeRange.test.ts
@@ -1,0 +1,147 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import TimeRange from "./TimeRange.test.svelte";
+
+describe("TimeRange", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+
+  const START = "2024-01-05";
+  const END = "2024-01-10T00:00:00.000Z";
+
+  afterEach(() => {
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("default render: two <time> elements with correct datetime and formatted text", () => {
+    instance = mount(TimeRange, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="default"]').querySelectorAll("time");
+    expect(times.length).toEqual(2);
+
+    expect(times[0]!.getAttribute("datetime")).toEqual(START);
+    expect(times[0]!.textContent).toEqual(dayjs(START).format("MMM DD, YYYY"));
+
+    expect(times[1]!.getAttribute("datetime")).toEqual(END);
+    expect(times[1]!.textContent).toEqual(dayjs(END).format("MMM DD, YYYY"));
+
+    expect(getElement('[data-test="default"]').textContent).toEqual(
+      `${dayjs(START).format("MMM DD, YYYY")} – ${dayjs(END).format("MMM DD, YYYY")}`,
+    );
+  });
+
+  test("custom format applies independently to both endpoints", () => {
+    instance = mount(TimeRange, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="custom-format"]').querySelectorAll(
+      "time",
+    );
+    expect(times[0]!.textContent).toEqual("2024-01-05");
+    expect(times[1]!.textContent).toEqual(dayjs(END).format("YYYY-MM-DD"));
+  });
+
+  test("custom separator", () => {
+    instance = mount(TimeRange, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="custom-separator"]').textContent).toEqual(
+      `${dayjs(START).format("MMM DD, YYYY")} to ${dayjs(END).format("MMM DD, YYYY")}`,
+    );
+  });
+
+  test("locale applies independently to both endpoints", () => {
+    instance = mount(TimeRange, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="locale"]').querySelectorAll("time");
+    expect(times[0]!.textContent).toEqual(
+      dayjs(START).locale("de").format("MMMM"),
+    );
+    expect(times[1]!.textContent).toEqual(
+      dayjs(END).locale("de").format("MMMM"),
+    );
+  });
+
+  test("...rest props spread onto both <time> elements", () => {
+    instance = mount(TimeRange, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="rest-props"]').querySelectorAll(
+      "time",
+    );
+    for (const time of times) {
+      expect(time.getAttribute("class")).toEqual("range");
+      expect(time.getAttribute("data-foo")).toEqual("bar");
+    }
+  });
+
+  test("children snippet receives all four arguments and fully replaces default markup", () => {
+    instance = mount(TimeRange, { target: document.body });
+    flushSync();
+
+    expect(
+      getElement('[data-test="children"]').querySelectorAll("time").length,
+    ).toEqual(0);
+
+    expect(getElement('[data-test="children-start"]').textContent).toEqual(
+      dayjs(START).format("MMM DD, YYYY"),
+    );
+    expect(getElement('[data-test="children-end"]').textContent).toEqual(
+      dayjs(END).format("MMM DD, YYYY"),
+    );
+    expect(
+      getElement('[data-test="children-start-datetime"]').textContent,
+    ).toEqual(START);
+    expect(
+      getElement('[data-test="children-end-datetime"]').textContent,
+    ).toEqual(END);
+  });
+});
+
+// Isolated: dayjs plugin extension mutates the shared `dayjs` singleton for
+// the lifetime of the Vitest worker, so a fresh, unextended copy is needed
+// to test the missing-plugin error path. See TimezoneMissingPlugin.test.ts.
+describe("TimeRange tz prop without utc/timezone plugins extended", () => {
+  test("throws a clear, actionable error", async () => {
+    vi.resetModules();
+
+    const { dayjs } = await import("../src/dayjs.js");
+    expect(typeof (dayjs() as any).tz).not.toEqual("function");
+
+    const { default: TimeRange } = await import("../src/TimeRange.svelte");
+    const { mount, flushSync, unmount } = await import("svelte");
+
+    let thrown: unknown;
+    let instance: ReturnType<typeof mount> | undefined;
+    try {
+      instance = mount(TimeRange, {
+        target: document.body,
+        props: {
+          start: "2013-11-18T11:55:20Z",
+          end: "2013-11-19T11:55:20Z",
+          tz: "America/Toronto",
+        },
+      });
+      flushSync();
+    } catch (error) {
+      thrown = error;
+    } finally {
+      if (instance) unmount(instance);
+      document.body.innerHTML = "";
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(
+      /svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins/,
+    );
+  }, 15_000);
+});

--- a/tests/TimeRangeAttachment.test.svelte
+++ b/tests/TimeRangeAttachment.test.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: `timeRange` is used in the {@attach} directives below
+  import { timeRange } from "svelte-time";
+
+  const START = "2024-01-05";
+  const END = "2024-01-10T00:00:00.000Z";
+
+  // biome-ignore lint/correctness/noUnusedVariables: used in the {@attach} directive below
+  let start = $state(START);
+  // biome-ignore lint/correctness/noUnusedVariables: used in the {@attach} directive below
+  let end = $state(END);
+</script>
+
+<span
+  data-test="basic"
+  {@attach timeRange({ start: START, end: END })}
+></span>
+
+<span
+  data-test="format"
+  {@attach timeRange({ start: START, end: END, format: "YYYY-MM-DD" })}
+></span>
+
+<span
+  data-test="separator"
+  {@attach timeRange({ start: START, end: END, separator: " to " })}
+></span>
+
+<span
+  data-test="locale"
+  {@attach timeRange({ start: START, end: END, format: "MMMM", locale: "de" })}
+></span>
+
+<span
+  data-test="reactive"
+  {@attach timeRange({ start, end })}
+></span>
+<button
+  type="button"
+  onclick={() => {
+    start = "2024-02-05";
+    end = "2024-02-10T00:00:00.000Z";
+  }}
+>
+  Update
+</button>

--- a/tests/TimeRangeAttachment.test.ts
+++ b/tests/TimeRangeAttachment.test.ts
@@ -1,0 +1,121 @@
+import dayjs from "dayjs";
+import { flushSync, mount, unmount } from "svelte";
+import TimeRangeAttachment from "./TimeRangeAttachment.test.svelte";
+
+describe("timeRange attachment", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+
+  const START = "2024-01-05";
+  const END = "2024-01-10T00:00:00.000Z";
+
+  afterEach(() => {
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    return document.querySelector(selector) as HTMLElement;
+  };
+
+  test("basic render: two <time> children with correct datetime and text", () => {
+    instance = mount(TimeRangeAttachment, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="basic"]').querySelectorAll("time");
+    expect(times.length).toEqual(2);
+    expect(times[0]!.getAttribute("datetime")).toEqual(START);
+    expect(times[0]!.textContent).toEqual(dayjs(START).format("MMM DD, YYYY"));
+    expect(times[1]!.getAttribute("datetime")).toEqual(END);
+    expect(times[1]!.textContent).toEqual(dayjs(END).format("MMM DD, YYYY"));
+    expect(getElement('[data-test="basic"]').textContent).toEqual(
+      `${dayjs(START).format("MMM DD, YYYY")} – ${dayjs(END).format("MMM DD, YYYY")}`,
+    );
+  });
+
+  test("format controls the displayed template on both endpoints", () => {
+    instance = mount(TimeRangeAttachment, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="format"]').querySelectorAll("time");
+    expect(times[0]!.textContent).toEqual("2024-01-05");
+    expect(times[1]!.textContent).toEqual(dayjs(END).format("YYYY-MM-DD"));
+  });
+
+  test("separator is rendered between the two <time> elements", () => {
+    instance = mount(TimeRangeAttachment, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="separator"]').textContent).toEqual(
+      `${dayjs(START).format("MMM DD, YYYY")} to ${dayjs(END).format("MMM DD, YYYY")}`,
+    );
+  });
+
+  test("locale applies to both endpoints", () => {
+    instance = mount(TimeRangeAttachment, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="locale"]').querySelectorAll("time");
+    expect(times[0]!.textContent).toEqual(
+      dayjs(START).locale("de").format("MMMM"),
+    );
+    expect(times[1]!.textContent).toEqual(
+      dayjs(END).locale("de").format("MMMM"),
+    );
+  });
+
+  test("reactivity: re-runs when a reactive value used to build options changes", () => {
+    instance = mount(TimeRangeAttachment, { target: document.body });
+    flushSync();
+
+    const times = getElement('[data-test="reactive"]').querySelectorAll("time");
+    expect(times[0]!.getAttribute("datetime")).toEqual(START);
+
+    getElement("button").click();
+    flushSync();
+
+    const updatedTimes = getElement('[data-test="reactive"]').querySelectorAll(
+      "time",
+    );
+    expect(updatedTimes[0]!.getAttribute("datetime")).toEqual("2024-02-05");
+    expect(updatedTimes[1]!.getAttribute("datetime")).toEqual(
+      "2024-02-10T00:00:00.000Z",
+    );
+  });
+});
+
+// Isolated: dayjs plugin extension mutates the shared `dayjs` singleton for
+// the lifetime of the Vitest worker. See TimezoneMissingPlugin.test.ts.
+describe("timeRange attachment tz option without utc/timezone plugins extended", () => {
+  test("throws a clear, actionable error", async () => {
+    vi.resetModules();
+
+    const { dayjs } = await import("../src/dayjs.js");
+    expect(typeof (dayjs() as any).tz).not.toEqual("function");
+
+    const { timeRange } = await import("../src/attachment.js");
+
+    const node = document.createElement("span");
+    document.body.appendChild(node);
+
+    let thrown: unknown;
+    try {
+      timeRange({
+        start: "2013-11-18T11:55:20Z",
+        end: "2013-11-19T11:55:20Z",
+        tz: "America/Toronto",
+      })(node);
+    } catch (error) {
+      thrown = error;
+    } finally {
+      document.body.innerHTML = "";
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(
+      /svelte-time: the `tz` prop requires the dayjs `utc` and `timezone` plugins/,
+    );
+  }, 15_000);
+});

--- a/tests/TimeRangeTimezone.test.ts
+++ b/tests/TimeRangeTimezone.test.ts
@@ -1,0 +1,101 @@
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { flushSync, mount, unmount } from "svelte";
+import { dayjs, svelteTimeRange, TimeRange, timeRange } from "svelte-time";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// Isolated in its own file, mirroring Timezone.test.ts: keeping the tz
+// success path (which requires the utc/timezone plugins extended) separate
+// from TimeRange.test.ts's missing-plugin case avoids tainting the shared
+// dayjs singleton the missing-plugin test depends on being unextended.
+describe("TimeRange tz prop", () => {
+  const START = "2013-11-18T11:55:20Z";
+  const END = "2013-11-19T11:55:20Z";
+  const FORMAT = "YYYY-MM-DDTHH:mm:ss";
+  const ZONE = "America/Toronto";
+
+  let instance: null | ReturnType<typeof mount> = null;
+
+  afterEach(() => {
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  function renderComponent(
+    props: { start: string; end: string } & Record<string, unknown>,
+  ) {
+    instance = mount(TimeRange, { target: document.body, props });
+    flushSync();
+    return document.body.querySelectorAll("time");
+  }
+
+  test("basic conversion: renders the zone's local wall-clock time for both endpoints", () => {
+    const expectedStart = dayjs(START).tz(ZONE).format(FORMAT);
+    const expectedEnd = dayjs(END).tz(ZONE).format(FORMAT);
+
+    const times = renderComponent({
+      start: START,
+      end: END,
+      tz: ZONE,
+      format: FORMAT,
+    });
+
+    expect(times[0]!.textContent).toEqual(expectedStart);
+    expect(times[1]!.textContent).toEqual(expectedEnd);
+    // Sanity: the conversion actually changed the wall-clock value.
+    expect(expectedEnd).not.toEqual(dayjs(END).format(FORMAT));
+  });
+
+  test("datetime attributes are unaffected by tz", () => {
+    const times = renderComponent({ start: START, end: END, tz: ZONE });
+
+    expect(times[0]!.getAttribute("datetime")).toEqual(START);
+    expect(times[1]!.getAttribute("datetime")).toEqual(END);
+  });
+
+  test("action: renders the zone's local wall-clock time for both endpoints", () => {
+    const node = document.createElement("span");
+    document.body.appendChild(node);
+
+    svelteTimeRange(node, { start: START, end: END, tz: ZONE, format: FORMAT });
+    const times = node.querySelectorAll("time");
+
+    expect(times[0]!.textContent).toEqual(dayjs(START).tz(ZONE).format(FORMAT));
+    expect(times[1]!.textContent).toEqual(dayjs(END).tz(ZONE).format(FORMAT));
+
+    document.body.innerHTML = "";
+  });
+
+  test("attachment: renders the zone's local wall-clock time for both endpoints", () => {
+    const node = document.createElement("span");
+    document.body.appendChild(node);
+
+    timeRange({ start: START, end: END, tz: ZONE, format: FORMAT })(node);
+    const times = node.querySelectorAll("time");
+
+    expect(times[0]!.textContent).toEqual(dayjs(START).tz(ZONE).format(FORMAT));
+    expect(times[1]!.textContent).toEqual(dayjs(END).tz(ZONE).format(FORMAT));
+
+    document.body.innerHTML = "";
+  });
+
+  test("unknown zone name: propagates dayjs/Intl's own RangeError, not our plugin-guard message", () => {
+    const props = { start: START, end: END, tz: "Not/AZone", format: FORMAT };
+
+    expect(() => renderComponent(props)).toThrow(RangeError);
+    expect(() => renderComponent(props)).toThrow(/invalid time zone/i);
+
+    const actionNode = document.createElement("span");
+    document.body.appendChild(actionNode);
+    expect(() => svelteTimeRange(actionNode, props)).toThrow(RangeError);
+
+    const attachmentNode = document.createElement("span");
+    document.body.appendChild(attachmentNode);
+    expect(() => timeRange(props)(attachmentNode)).toThrow(RangeError);
+  });
+});

--- a/tests/examples/TimeRangeBasic.svelte
+++ b/tests/examples/TimeRangeBasic.svelte
@@ -1,0 +1,9 @@
+<script>
+  import { TimeRange } from "svelte-time";
+</script>
+
+<!-- An event's start/end -->
+<TimeRange
+  start="2024-06-05"
+  end="2024-06-10"
+/>

--- a/tests/examples/TimeRangeCustomMarkup.svelte
+++ b/tests/examples/TimeRangeCustomMarkup.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { dayjs, TimeRange } from "svelte-time";
+
+  const start = "2024-06-05T08:00:00";
+  const end = "2024-06-05T10:00:00";
+</script>
+
+<!-- Condensed: date once, time on each side -->
+<TimeRange
+  {start}
+  {end}
+>
+  {#snippet children({ startDatetime, endDatetime })}
+    <time datetime={startDatetime}>{dayjs(start).format("MMM D, h:mm A")}</time>
+    –
+    <time datetime={endDatetime}>{dayjs(end).format("h:mm A")}</time>
+  {/snippet}
+</TimeRange>
+<!-- Output: "Jun 5, 8:00 AM – 10:00 AM" -->

--- a/tests/examples/TimeRangeLocale.svelte
+++ b/tests/examples/TimeRangeLocale.svelte
@@ -1,0 +1,11 @@
+<script>
+  import "dayjs/locale/de";
+  import { TimeRange } from "svelte-time";
+</script>
+
+<TimeRange
+  start="2024-06-05"
+  end="2024-06-10"
+  format="D. MMMM"
+  locale="de"
+/>

--- a/tests/examples/TimeRangeMeeting.svelte
+++ b/tests/examples/TimeRangeMeeting.svelte
@@ -1,0 +1,10 @@
+<script>
+  import { TimeRange } from "svelte-time";
+</script>
+
+<!-- A same-day meeting window -->
+<TimeRange
+  start="2024-06-05T08:00:00"
+  end="2024-06-05T10:00:00"
+  format="h:mm A"
+/>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -5,6 +5,7 @@ test("Library has exports", () => {
     "Countdown",
     "Duration",
     "Stopwatch",
+    "TimeRange",
     "countdown",
     "dayjs",
     "default",
@@ -17,6 +18,8 @@ test("Library has exports", () => {
     "svelteDuration",
     "svelteStopwatch",
     "svelteTime",
+    "svelteTimeRange",
     "time",
+    "timeRange",
   ]);
 });

--- a/tests/ssr/TimeRange.ssr.test.ts
+++ b/tests/ssr/TimeRange.ssr.test.ts
@@ -1,0 +1,66 @@
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+import { render } from "svelte/server";
+import { dayjs, TimeRange } from "svelte-time";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+describe("TimeRange (SSR)", () => {
+  const START = "2024-01-05";
+  const END = "2024-01-10T00:00:00.000Z";
+
+  test("renders two populated <time> elements on the server", () => {
+    const { body } = render(TimeRange, { props: { start: START, end: END } });
+
+    expect(body).toContain(`<time datetime="${START}"`);
+    expect(body).toContain(dayjs(START).format("MMM DD, YYYY"));
+    expect(body).toContain(`<time datetime="${END}"`);
+    expect(body).toContain(dayjs(END).format("MMM DD, YYYY"));
+  });
+
+  test("normalizes Date inputs to ISO in the server-rendered datetime attributes", () => {
+    const start = new Date(START);
+    const end = new Date(END);
+    const { body } = render(TimeRange, { props: { start, end } });
+
+    expect(body).toContain(`datetime="${start.toISOString()}"`);
+    expect(body).toContain(`datetime="${end.toISOString()}"`);
+  });
+
+  test("format applies independently to both endpoints", () => {
+    const { body } = render(TimeRange, {
+      props: { start: START, end: END, format: "YYYY-MM-DD" },
+    });
+
+    expect(body).toContain(">2024-01-05<");
+    expect(body).toContain(`>${dayjs(END).format("YYYY-MM-DD")}<`);
+  });
+
+  test("separator is rendered between the two <time> elements", () => {
+    const { body } = render(TimeRange, {
+      props: { start: START, end: END, separator: " to " },
+    });
+
+    expect(body).toContain("</time> to <time");
+  });
+
+  test("never renders 'Invalid Date' for valid inputs", () => {
+    const { body } = render(TimeRange, { props: { start: START, end: END } });
+    expect(body).not.toContain("Invalid Date");
+  });
+
+  test("tz prop renders the zoned wall-clock time in the server HTML", () => {
+    const zone = "America/Toronto";
+    const format = "YYYY-MM-DDTHH:mm:ss";
+    const expectedStart = dayjs(START).tz(zone).format(format);
+    const expectedEnd = dayjs(END).tz(zone).format(format);
+
+    const { body } = render(TimeRange, {
+      props: { start: START, end: END, tz: zone, format },
+    });
+
+    expect(body).toContain(expectedStart);
+    expect(body).toContain(expectedEnd);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `TimeRange` component (+ `svelteTimeRange` action, `timeRange` attachment) that formats a span between two fixed instants (e.g. an event's start/end).
- Renders two `<time>` elements (one per endpoint) since a single `datetime` attribute can't represent a range.
- v1 is intentionally simple: `format` applies independently to each side, no "smart" Intl-style range collapsing (e.g. deduping a shared year/month) — noted as a possible future enhancement.
- Docs: new `## Time Range` README section, props table, cross-link from `Duration`.

## Test plan
- [x] `bun run test` passes
- [x] `bun run check` passes
- [x] `bun run lint` is clean
- [x] SSR test renders both `<time>` elements correctly
- [ ] Manually verify the `TimeRangeBasic` doc example in the dev server