### PR TITLE
test: cover explicit runes-mode consumption for every primitive

### DIFF
--- a/src/svelte-countdown.svelte.js
+++ b/src/svelte-countdown.svelte.js
@@ -12,6 +12,8 @@ export const svelteCountdown = (node, options = {}) => {
   /** @type {undefined | NodeJS.Timeout} */
   let interval;
   let completed = false;
+  /** @type {import("dayjs").ConfigType} */
+  let lastTo;
 
   /** @param {Partial<SvelteCountdownOptions>} [options] */
   const render = (options = {}) => {
@@ -47,7 +49,11 @@ export const svelteCountdown = (node, options = {}) => {
   const updateCountdown = (options = {}) => {
     clearInterval(interval);
     interval = undefined;
-    completed = false;
+
+    if (options.to !== lastTo) {
+      completed = false;
+      lastTo = options.to;
+    }
 
     render(options);
 

--- a/tests/RunesActionConsumer.test.svelte
+++ b/tests/RunesActionConsumer.test.svelte
@@ -1,0 +1,67 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  import { svelteCountdown, svelteDuration, svelteTime } from "svelte-time";
+
+  let timestamp = $state("2020-02-01");
+  let since = $state("2023-12-31T23:59:00.000Z");
+  let to = $state(new Date("2024-01-01T00:05:00.000Z"));
+  let completedCalls = $state(0);
+
+  function bumpTimestamp() {
+    timestamp = "2021-03-15";
+  }
+
+  function bumpSince() {
+    since = "2023-12-31T23:50:00.000Z";
+  }
+
+  function completeCountdown() {
+    to = new Date(Date.now() - 1000);
+  }
+
+  function handleCountdownComplete() {
+    completedCalls++;
+  }
+</script>
+
+<time
+  data-test="time"
+  use:svelteTime={{ timestamp }}
+></time>
+<button
+  type="button"
+  data-test="btn-time"
+  onclick={bumpTimestamp}
+>
+  Update timestamp
+</button>
+
+<time
+  data-test="duration"
+  use:svelteDuration={{ since, live: false }}
+></time>
+<button
+  type="button"
+  data-test="btn-duration"
+  onclick={bumpSince}
+>
+  Update since
+</button>
+
+<time
+  data-test="countdown"
+  use:svelteCountdown={{
+    to,
+    live: false,
+    oncomplete: handleCountdownComplete,
+  }}
+></time>
+<span data-test="countdown-oncomplete-calls">{completedCalls}</span>
+<button
+  type="button"
+  data-test="btn-countdown"
+  onclick={completeCountdown}
+>
+  Complete countdown
+</button>

--- a/tests/RunesActionConsumer.test.ts
+++ b/tests/RunesActionConsumer.test.ts
@@ -1,0 +1,69 @@
+import { flushSync, mount, unmount } from "svelte";
+import RunesActionConsumer from "./RunesActionConsumer.test.svelte";
+
+describe("runes action consumer (explicit runes={true})", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("svelteTime action updates when a $state option changes", () => {
+    instance = mount(RunesActionConsumer, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="time"]');
+    expect(el.textContent).toEqual("Feb 01, 2020");
+
+    getElement('[data-test="btn-time"]').click();
+    flushSync();
+
+    expect(el.textContent).toEqual("Mar 15, 2021");
+  });
+
+  test("svelteDuration action updates when `since` changes", () => {
+    instance = mount(RunesActionConsumer, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="duration"]');
+    expect(el.textContent).toEqual("00:01:00");
+
+    getElement('[data-test="btn-duration"]').click();
+    flushSync();
+
+    expect(el.textContent).toEqual("00:10:00");
+  });
+
+  test("svelteCountdown action fires `oncomplete` once when `to` moves into the past", () => {
+    instance = mount(RunesActionConsumer, { target: document.body });
+    flushSync();
+
+    expect(
+      getElement('[data-test="countdown-oncomplete-calls"]').textContent,
+    ).toEqual("0");
+
+    getElement('[data-test="btn-countdown"]').click();
+    flushSync();
+
+    expect(
+      getElement('[data-test="countdown-oncomplete-calls"]').textContent,
+    ).toEqual("1");
+  });
+});

--- a/tests/RunesAttachmentConsumer.test.svelte
+++ b/tests/RunesAttachmentConsumer.test.svelte
@@ -1,0 +1,67 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: `time`, `duration`, and `countdown` are used in the {@attach} directives below
+  import { countdown, duration, time } from "svelte-time";
+
+  // biome-ignore lint/correctness/noUnusedVariables: used in the {@attach} directives below
+  let timestamp = $state("2020-02-01");
+  // biome-ignore lint/correctness/noUnusedVariables: used in the {@attach} directives below
+  let since = $state("2023-12-31T23:59:00.000Z");
+  // biome-ignore lint/correctness/noUnusedVariables: used in the {@attach} directives below
+  let to = $state(new Date("2024-01-01T00:05:00.000Z"));
+  let completedCalls = $state(0);
+
+  function bumpTimestamp() {
+    timestamp = "2021-03-15";
+  }
+
+  function bumpSince() {
+    since = "2023-12-31T23:50:00.000Z";
+  }
+
+  function completeCountdown() {
+    to = new Date(Date.now() - 1000);
+  }
+</script>
+
+<time
+  data-test="time"
+  {@attach time({ timestamp })}
+></time>
+<button
+  type="button"
+  data-test="btn-time"
+  onclick={bumpTimestamp}
+>
+  Update timestamp
+</button>
+
+<time
+  data-test="duration"
+  {@attach duration({ since, live: false })}
+></time>
+<button
+  type="button"
+  data-test="btn-duration"
+  onclick={bumpSince}
+>
+  Update since
+</button>
+
+<time
+  data-test="countdown"
+  {@attach countdown({
+    to,
+    live: false,
+    oncomplete: () => completedCalls++,
+  })}
+></time>
+<span data-test="countdown-oncomplete-calls">{completedCalls}</span>
+<button
+  type="button"
+  data-test="btn-countdown"
+  onclick={completeCountdown}
+>
+  Complete countdown
+</button>

--- a/tests/RunesAttachmentConsumer.test.ts
+++ b/tests/RunesAttachmentConsumer.test.ts
@@ -1,0 +1,69 @@
+import { flushSync, mount, unmount } from "svelte";
+import RunesAttachmentConsumer from "./RunesAttachmentConsumer.test.svelte";
+
+describe("runes attachment consumer (explicit runes={true})", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("time attachment updates when a $state option changes", () => {
+    instance = mount(RunesAttachmentConsumer, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="time"]');
+    expect(el.textContent).toEqual("Feb 01, 2020");
+
+    getElement('[data-test="btn-time"]').click();
+    flushSync();
+
+    expect(el.textContent).toEqual("Mar 15, 2021");
+  });
+
+  test("duration attachment updates when `since` changes", () => {
+    instance = mount(RunesAttachmentConsumer, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="duration"]');
+    expect(el.textContent).toEqual("00:01:00");
+
+    getElement('[data-test="btn-duration"]').click();
+    flushSync();
+
+    expect(el.textContent).toEqual("00:10:00");
+  });
+
+  test("countdown attachment fires `oncomplete` once when `to` moves into the past", () => {
+    instance = mount(RunesAttachmentConsumer, { target: document.body });
+    flushSync();
+
+    expect(
+      getElement('[data-test="countdown-oncomplete-calls"]').textContent,
+    ).toEqual("0");
+
+    getElement('[data-test="btn-countdown"]').click();
+    flushSync();
+
+    expect(
+      getElement('[data-test="countdown-oncomplete-calls"]').textContent,
+    ).toEqual("1");
+  });
+});

--- a/tests/RunesComponentConsumer.test.svelte
+++ b/tests/RunesComponentConsumer.test.svelte
@@ -1,0 +1,72 @@
+<svelte:options runes={true} />
+
+<script lang="ts">
+  import Time, { Countdown, Duration } from "svelte-time";
+
+  let timestamp = $state("2020-02-01");
+  let since = $state("2023-12-31T23:59:00.000Z");
+  let to = $state(new Date("2024-01-01T00:05:00.000Z"));
+  let completedCalls = $state(0);
+
+  function bumpTimestamp() {
+    timestamp = "2021-03-15";
+  }
+
+  function bumpSince() {
+    since = "2023-12-31T23:50:00.000Z";
+  }
+
+  function completeCountdown() {
+    to = new Date(Date.now() - 1000);
+  }
+</script>
+
+<Time
+  data-test="time"
+  {timestamp}
+/>
+<button
+  type="button"
+  data-test="btn-time"
+  onclick={bumpTimestamp}
+>
+  Update timestamp
+</button>
+
+<Duration
+  data-test="duration"
+  {since}
+  live={false}
+/>
+<button
+  type="button"
+  data-test="btn-duration"
+  onclick={bumpSince}
+>
+  Update since
+</button>
+
+<Countdown
+  data-test="countdown"
+  {to}
+  live={false}
+  oncomplete={() => completedCalls++}
+/>
+<span data-test="countdown-oncomplete-calls">{completedCalls}</span>
+<button
+  type="button"
+  data-test="btn-countdown"
+  onclick={completeCountdown}
+>
+  Complete countdown
+</button>
+
+<!-- Multiple instances mounted together stay independently reactive -->
+<Time
+  data-test="time-a"
+  timestamp="2020-01-01"
+/>
+<Time
+  data-test="time-b"
+  timestamp="2021-01-01"
+/>

--- a/tests/RunesComponentConsumer.test.ts
+++ b/tests/RunesComponentConsumer.test.ts
@@ -1,0 +1,81 @@
+import { flushSync, mount, unmount } from "svelte";
+import RunesComponentConsumer from "./RunesComponentConsumer.test.svelte";
+
+describe("runes component consumer (explicit runes={true})", () => {
+  let instance: null | ReturnType<typeof mount> = null;
+  const FIXED_DATE = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_DATE);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (instance) {
+      unmount(instance);
+    }
+    instance = null;
+    document.body.innerHTML = "";
+  });
+
+  const getElement = (selector: string) => {
+    const element = document.querySelector(selector);
+    assert(element instanceof HTMLElement);
+    return element;
+  };
+
+  test("Time re-renders when a $state prop changes", () => {
+    instance = mount(RunesComponentConsumer, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="time"]');
+    expect(el.innerHTML).toEqual("Feb 01, 2020");
+
+    getElement('[data-test="btn-time"]').click();
+    flushSync();
+
+    expect(el.innerHTML).toEqual("Mar 15, 2021");
+  });
+
+  test("Duration re-renders when `since` changes", () => {
+    instance = mount(RunesComponentConsumer, { target: document.body });
+    flushSync();
+
+    const el = getElement('[data-test="duration"]');
+    expect(el.textContent).toEqual("00:01:00");
+
+    getElement('[data-test="btn-duration"]').click();
+    flushSync();
+
+    expect(el.textContent).toEqual("00:10:00");
+  });
+
+  test("Countdown fires `oncomplete` once when `to` moves into the past", () => {
+    instance = mount(RunesComponentConsumer, { target: document.body });
+    flushSync();
+
+    expect(
+      getElement('[data-test="countdown-oncomplete-calls"]').textContent,
+    ).toEqual("0");
+
+    getElement('[data-test="btn-countdown"]').click();
+    flushSync();
+
+    expect(
+      getElement('[data-test="countdown-oncomplete-calls"]').textContent,
+    ).toEqual("1");
+  });
+
+  test("multiple component instances stay independently reactive", () => {
+    instance = mount(RunesComponentConsumer, { target: document.body });
+    flushSync();
+
+    expect(getElement('[data-test="time-a"]').innerHTML).toEqual(
+      "Jan 01, 2020",
+    );
+    expect(getElement('[data-test="time-b"]').innerHTML).toEqual(
+      "Jan 01, 2021",
+    );
+  });
+});


### PR DESCRIPTION
The compatibility table documents that svelte-time@2 consumers don't
need runes mode enabled, but only the legacy side of that claim had
explicit coverage. Nothing locked the runes side in, or guarded
against `vite.config`'s global `runes: true` default masking a
regression in a runes-mode consumer.

Adds fixtures with an explicit `<svelte:options runes={true}/>` for
the component, action, and attachment form of `Time`, `Duration`,
and `Countdown`, driven by `$state` and callback props, mirroring
the existing explicit legacy-mode coverage pattern.

Building the action fixture surfaced a real bug: `svelteCountdown`
reset its internal `completed` flag on every `update()` call instead
of only when `to` changed. An `oncomplete` callback that writes to
other consumer state re-triggers `update()`, which re-fired
`oncomplete` in an infinite loop. Fixed by tracking the last `to`
value and only resetting on an actual change, matching the guard
already used by the `Countdown` component and `countdown` attachment.

Risk is low for the test changes. The `svelteCountdown` fix narrows
when `completed` resets, so the only behavior change is that calling
`update()` without `to` changing no longer re-arms completion.