### PR TITLE
feat: add `svelte-time/intl`, a zero-dependency Intl-based alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,392 @@ Formats a timestamp as a string with byte-identical output to the `<Time>` compo
 
 Formats a relative time string with byte-identical output to the `<Time>` component's `relative` prop. Pass `from` to set the reference point — use `now(...)` for a result that stays live.
 
+## `svelte-time/intl` (zero-dependency alternative)
+
+A zero-dependency alternative built on the browser/runtime's native `Intl` APIs instead of dayjs — no external package, no locale files to import, no plugins. It ships alongside (not instead of) the dayjs-based `Time`/`Duration`/`Countdown` primitives above.
+
+> **Trade-off:** this is a formatting-only layer, not a drop-in dayjs replacement. It cannot parse arbitrary date strings, cannot do date arithmetic (`add`/`diff`/`startOf`, etc.), and has no custom token format strings (`"MMM DD, YYYY"`) — it only formats a `Date`/timestamp you already have, using `Intl.DateTimeFormatOptions` fields or `dateStyle`/`timeStyle` presets instead. It also depends on `Intl.DurationFormat`, the newest of the three `Intl` APIs it uses (Baseline since March 2025 — meaningfully less battle-tested than `DateTimeFormat`/`RelativeTimeFormat`, which have been widely available since 2020). See the [full comparison](#svelte-time-vs-svelte-timeintl) below before reaching for this over the dayjs-based package.
+
+`Intl.DateTimeFormat`, `Intl.RelativeTimeFormat`, and `Intl.DurationFormat` are all Baseline widely available in modern browsers, Node, Bun, and Deno — so this subpackage adds zero bytes to your bundle beyond what the platform already ships. Import it from `svelte-time/intl` instead of `svelte-time`.
+
+```bash
+# Same install as above — svelte-time/intl is a subpath of the same package
+npm i svelte-time
+```
+
+It mirrors the same primitives as the main package (component, action, attachment) for `Time`, `TimeRange`, `Stopwatch`, and `Countdown` — there's no intl counterpart to `Duration` since `formatDuration` (below) already covers fixed-span formatting without a component wrapper.
+
+| Primitive  | Export            | Notes                                                          |
+| :--------- | :---------------- | :---------------------------------------------------------------- |
+| Component  | `Time`            | same shape as the main `Time` component                          |
+| Component  | `TimeRange`       | renders a single condensed range via `formatRange` (see below)   |
+| Component  | `Stopwatch`       | same shape as the main `Stopwatch` component                     |
+| Component  | `Countdown`       | same shape as the main `Countdown` component                     |
+| Action     | `svelteTime`      | same shape as the main `svelteTime` action                        |
+| Action     | `svelteTimeRange` | same shape as the main `svelteTimeRange` action                  |
+| Action     | `svelteStopwatch` | same shape as the main `svelteStopwatch` action                  |
+| Action     | `svelteCountdown` | same shape as the main `svelteCountdown` action                  |
+| Attachment | `time`            | same shape as the main `time` attachment                         |
+| Attachment | `timeRange`       | attachment version of `TimeRange`                                 |
+| Attachment | `stopwatch`       | attachment version of `Stopwatch`                                 |
+| Attachment | `countdown`       | attachment version of `Countdown`                                 |
+
+### `Time` component
+
+`options` is a plain [`Intl.DateTimeFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) object instead of a dayjs token string. The default is `dateStyle: "medium"`.
+
+<!-- render:IntlBasic -->
+
+```svelte
+<script>
+  import { Time } from "svelte-time/intl";
+</script>
+
+<Time />
+```
+
+<!-- render:IntlCustomOptions -->
+
+```svelte
+<Time
+  timestamp="2020-02-01"
+  options={{ weekday: "long", year: "numeric", month: "short", day: "numeric" }}
+/>
+
+<Time timestamp={new Date()} options={{ year: "numeric", month: "2-digit", day: "2-digit" }} />
+```
+
+### `dateStyle` / `timeStyle` presets
+
+`Intl.DateTimeFormat`'s built-in style presets (`"short"`, `"medium"`, `"long"`, `"full"`) are a locale-aware alternative to hand-writing a token string.
+
+<!-- render:IntlDateStyle -->
+
+```svelte
+<Time {timestamp} options={{ dateStyle: "short" }} />
+<Time {timestamp} options={{ dateStyle: "full" }} />
+<Time {timestamp} options={{ dateStyle: "medium", timeStyle: "short" }} />
+```
+
+### Relative time
+
+Set `relative` to `true`, same as the main package. `numeric` maps directly to [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat)'s option: `"auto"` (default) prefers words like "yesterday"/"tomorrow" where the locale has one; `"always"` forces the numeric form ("1 day ago").
+
+<!-- render:IntlRelative -->
+
+```svelte
+<Time relative timestamp={Date.now() - 4 * 86_400_000} />
+<Time relative timestamp={Date.now() + 2 * 3_600_000} />
+```
+
+<!-- render:IntlRelativeAlways -->
+
+```svelte
+<!-- numeric="auto" (default): "yesterday" -->
+<Time relative {timestamp} />
+
+<!-- numeric="always": "1 day ago" -->
+<Time relative {timestamp} numeric="always" />
+```
+
+### Live updates
+
+Same `live` prop as the main package's `Time` component — `true` for the adaptive shared-clock schedule, or a number for a fixed interval in ms.
+
+<!-- render:IntlLive -->
+
+```svelte
+<Time relative live {timestamp} />
+```
+
+### Locale
+
+Pass any [BCP-47 locale](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_identification_and_negotiation) tag directly — no separate locale files to import, unlike dayjs. The runtime's built-in ICU data covers every locale it supports.
+
+<!-- render:IntlLocale -->
+
+```svelte
+<Time {timestamp} locale="de" options={{ dateStyle: "long" }} />
+<Time {timestamp} locale="ja" options={{ dateStyle: "long" }} />
+<Time {timestamp} locale="ar" options={{ dateStyle: "long" }} />
+<Time relative {timestamp} locale="fr" />
+```
+
+### Alternate calendars and numbering systems
+
+`calendar` and `numberingSystem` are supported natively, with no plugins — something dayjs can't do without significant extra code.
+
+<!-- render:IntlCalendar -->
+
+```svelte
+<Time {timestamp} options={{ dateStyle: "long", calendar: "japanese" }} />
+<Time {timestamp} options={{ dateStyle: "long", calendar: "islamic" }} />
+<Time {timestamp} options={{ dateStyle: "long", calendar: "buddhist" }} />
+<Time {timestamp} options={{ dateStyle: "long", numberingSystem: "arab" }} />
+```
+
+### `TimeRange` component
+
+Formats a span between two dates via [`Intl.DateTimeFormat.prototype.formatRange`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/formatRange), which condenses the shared parts of the range (e.g. "Jan 10 – 15, 2026" instead of spelling out both full dates). Unlike the main package's `TimeRange` (which renders **two** `<time>` elements, one per endpoint, joined by a separator — necessary since a single `datetime` attribute can't hold a range), this renders **one** `<time>` element using the native condensed text, with an [ISO 8601 interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) (`start/end`) as its `datetime`.
+
+<!-- render:IntlTimeRange -->
+
+```svelte
+<script>
+  import { TimeRange } from "svelte-time/intl";
+</script>
+
+<!-- Output: "Jan 10 – 15, 2026" -->
+<TimeRange start="2026-01-10" end="2026-01-15" />
+
+<!-- Spans months/years automatically -->
+<TimeRange start="2026-01-10" end="2026-03-02" />
+
+<TimeRange start="2026-01-10" end="2026-01-15" options={{ dateStyle: "long" }} />
+```
+
+### `svelteTime` action
+
+Same shape as the main package's `svelteTime` action.
+
+<!-- render:IntlSvelteTimeAction -->
+
+```svelte
+<script>
+  import { svelteTime } from "svelte-time/intl";
+</script>
+
+<time use:svelteTime></time>
+
+<time
+  use:svelteTime={{
+    timestamp: "2021-02-02",
+    options: { dateStyle: "long" },
+  }}
+></time>
+```
+
+### `time` attachment
+
+<!-- render:IntlTimeAttachment -->
+
+```svelte
+<script>
+  import { time } from "svelte-time/intl";
+</script>
+
+<time {@attach time({ timestamp: "2021-02-02", options: { dateStyle: "long" } })}></time>
+```
+
+### `svelteTimeRange` action
+
+<!-- render:IntlSvelteTimeRangeAction -->
+
+```svelte
+<script>
+  import { svelteTimeRange } from "svelte-time/intl";
+</script>
+
+<time use:svelteTimeRange={{ start: "2026-01-10", end: "2026-01-15" }}></time>
+```
+
+### `timeRange` attachment
+
+<!-- render:IntlTimeRangeAttachment -->
+
+```svelte
+<script>
+  import { timeRange } from "svelte-time/intl";
+</script>
+
+<time {@attach timeRange({ start: "2026-01-10", end: "2026-01-15" })}></time>
+```
+
+### `Stopwatch` component
+
+Same shape as the main package's `Stopwatch` — counts up from a `since` instant, with a `running` prop for built-in pause/resume. `style` replaces `format`/`humanize`/`withSuffix`: `"digital"` (default) gives `"HH:mm:ss"`-style output; `"long"`/`"short"`/`"narrow"` give a humanized readout via `Intl.DurationFormat`.
+
+<!-- render:IntlStopwatchBasic -->
+
+```svelte
+<script>
+  import { Stopwatch } from "svelte-time/intl";
+
+  let since = $state(new Date());
+</script>
+
+<!-- Ticks live by default, once per second -->
+<Stopwatch {since} />
+
+<!-- Changing `since` restarts the stopwatch -->
+<button onclick={() => (since = new Date())}>Restart</button>
+```
+
+Pause and resume with the `running` prop; the `children` snippet receives the current `running` state alongside the formatted value:
+
+<!-- render:IntlStopwatchPause -->
+
+```svelte
+<script>
+  import { Stopwatch } from "svelte-time/intl";
+
+  const since = new Date();
+  let running = $state(true);
+</script>
+
+<Stopwatch {since} {running}>
+  {#snippet children(formatted, isRunning)}
+    {formatted}
+    {isRunning ? "(running)" : "(paused)"}
+  {/snippet}
+</Stopwatch>
+
+<button onclick={() => (running = !running)}>
+  {running ? "Pause" : "Resume"}
+</button>
+```
+
+### `svelteStopwatch` action
+
+```svelte
+<script>
+  import { svelteStopwatch } from "svelte-time/intl";
+
+  let running = $state(true);
+</script>
+
+<time use:svelteStopwatch={{ since: new Date(), running }}></time>
+```
+
+### `stopwatch` attachment
+
+```svelte
+<script>
+  import { stopwatch } from "svelte-time/intl";
+
+  let running = $state(true);
+</script>
+
+<time {@attach stopwatch({ since: new Date(), running })}></time>
+```
+
+### `Countdown` component
+
+Same shape as the main package's `Countdown` — counts down to a future `to` instant, clamped at zero, ticking every second by default.
+
+<!-- render:IntlCountdownBasic -->
+
+```svelte
+<script>
+  import { Countdown } from "svelte-time/intl";
+
+  let to = $state(new Date(Date.now() + 20_000));
+</script>
+
+<!-- Ticks live by default, once per second -->
+<Countdown {to} />
+
+<!-- style="long" gives a humanized readout -->
+<Countdown {to} style="long" />
+
+<!-- Changing `to` restarts the countdown -->
+<button onclick={() => (to = new Date(Date.now() + 20_000))}>Reset</button>
+```
+
+`oncomplete` fires once, when the countdown reaches `to`. The `children` snippet receives a `done` boolean alongside the formatted value.
+
+<!-- render:IntlCountdownOnComplete -->
+
+```svelte
+<script>
+  import { Countdown } from "svelte-time/intl";
+
+  let to = $state(new Date(Date.now() + 5000));
+</script>
+
+<Countdown {to} oncomplete={() => console.log("done!")}>
+  {#snippet children(formatted, done)}
+    {done ? "Done!" : formatted}
+  {/snippet}
+</Countdown>
+```
+
+### `svelteCountdown` action
+
+```svelte
+<script>
+  import { svelteCountdown } from "svelte-time/intl";
+</script>
+
+<time use:svelteCountdown={{ to: new Date(Date.now() + 20_000), oncomplete: () => console.log("done!") }}></time>
+```
+
+### `countdown` attachment
+
+```svelte
+<script>
+  import { countdown } from "svelte-time/intl";
+
+  const to = new Date(Date.now() + 20_000);
+</script>
+
+<time {@attach countdown({ to, oncomplete: () => console.log("done!") })}></time>
+```
+
+### `formatDuration(ms, options?)`
+
+Backed by [`Intl.DurationFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat) — `style` accepts `"digital"` (default, e.g. `"1:30:25"`), `"long"`, `"short"`, or `"narrow"`.
+
+<!-- render:IntlDuration -->
+
+```svelte
+<script>
+  import { formatDuration } from "svelte-time/intl";
+
+  const ms = 5_425_000; // 1h 30m 25s
+</script>
+
+<p>digital (default): {formatDuration(ms)}</p>
+<p>long: {formatDuration(ms, { style: "long" })}</p>
+<p>narrow: {formatDuration(ms, { style: "narrow" })}</p>
+<p>negative: {formatDuration(-42_000)}</p>
+```
+
+### Utility functions
+
+`formatTime`, `relativeTime`, and `formatRange` are also available standalone, for use outside a `<time>` element.
+
+<!-- render:IntlUtilities -->
+
+```svelte
+<script>
+  import { formatRange, formatTime, relativeTime } from "svelte-time/intl";
+
+  const timestamp = "2026-01-10T00:00:00Z";
+</script>
+
+<ul>
+  <li>formatTime: {formatTime(timestamp)}</li>
+  <li>relativeTime: {relativeTime(timestamp)}</li>
+  <li>formatRange: {formatRange(timestamp, "2026-01-15T00:00:00Z")}</li>
+</ul>
+```
+
+### `svelte-time` vs. `svelte-time/intl`
+
+`svelte-time/intl` trades away dayjs's parsing, arithmetic, and format-string flexibility for a zero-dependency footprint. If your app already depends on dayjs elsewhere, or needs any of the "no" rows below, use the dayjs-based package instead.
+
+| Aspect                    | `svelte-time` (dayjs)                                          | `svelte-time/intl`                                                       |
+| :------------------------ | :--------------------------------------------------------------- | :------------------------------------------------------------------------- |
+| Runtime dependency        | dayjs + `relativeTime`/`duration` plugins                        | none — built on platform `Intl` APIs                                       |
+| Format style              | token strings, e.g. `"MMM DD, YYYY"`                              | `Intl.DateTimeFormatOptions` fields, or `dateStyle`/`timeStyle` presets     |
+| Parsing arbitrary formats | yes, via dayjs                                                    | no — formats a `Date`/timestamp you already have                           |
+| Date arithmetic           | yes (`add`/`diff`/`startOf`, etc.)                                | no                                                                          |
+| Date ranges                | yes — `TimeRange` renders two `<time>` elements + separator      | yes — `TimeRange`/`formatRange` render one condensed native string        |
+| Alternate calendars/numbering systems | requires extra dayjs plugins                          | built in (`calendar`/`numberingSystem` options)                            |
+| Locale loading            | import each locale from `dayjs/locale/*`                         | none — covered by the runtime's built-in ICU data                          |
+| Browser baseline support  | n/a (bundled library)                                             | `DateTimeFormat`/`RelativeTimeFormat`/`formatRange`: widely available since 2020; `DurationFormat`: newer (Baseline since March 2025) |
+
 ## API
 
 ### `Time` component props

--- a/src/intl/Countdown.svelte
+++ b/src/intl/Countdown.svelte
@@ -1,0 +1,84 @@
+<script>
+  const {
+    /** Target instant to count down to. Changing `to` restarts the
+     * countdown.
+     * @type {import("./format").TimeInput} */
+    to,
+
+    /** @type {"digital" | "long" | "short" | "narrow"} */
+    style = "digital",
+
+    /** @type {string} */
+    locale = "en",
+
+    /** Set to `true` to tick every second. Pass a number (ms) for a
+     * custom fixed interval.
+     * @type {boolean | number} */
+    live = true,
+
+    /** Called once, when the countdown reaches `to`.
+     * @type {(() => void) | undefined} */
+    oncomplete,
+
+    /** @type {import("svelte").Snippet<[string, boolean]> | undefined} */
+    children,
+    ...rest
+  } = $props();
+
+  import { formatDuration, toISODuration } from "./format";
+  import { sharedNow } from "./ticker";
+
+  const canTick = typeof document !== "undefined";
+
+  let completed = $state(false);
+
+  $effect(() => {
+    to;
+    completed = false;
+  });
+
+  const effectiveInterval = $derived(
+    typeof live === "number" ? Math.abs(live) : 1_000,
+  );
+
+  const now = $derived(
+    live !== false && canTick && !completed
+      ? sharedNow(effectiveInterval)
+      : new Date(),
+  );
+
+  const remainingMs = $derived(
+    Math.max(0, new Date(to).getTime() - now.getTime()),
+  );
+
+  $effect(() => {
+    if (remainingMs === 0 && !completed) {
+      completed = true;
+      oncomplete?.();
+    }
+  });
+
+  const formatted = $derived(
+    formatDuration(remainingMs, {
+      locale,
+      style: /** @type {"digital" | "long" | "short" | "narrow"} */ (style),
+    }),
+  );
+  const datetime = $derived(toISODuration(remainingMs));
+</script>
+
+{#if children}
+  <time
+    {datetime}
+    {...rest}
+  >
+    {@render children(formatted, completed)}
+  </time>
+{:else}
+  <time
+    {datetime}
+    {...rest}
+  >
+    {formatted}
+  </time>
+{/if}

--- a/src/intl/Countdown.svelte.d.ts
+++ b/src/intl/Countdown.svelte.d.ts
@@ -1,0 +1,33 @@
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { TimeInput } from "./format";
+
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
+
+export interface CountdownProps extends RestProps {
+  /** Target instant to count down to. Changing `to` restarts the countdown. */
+  to: TimeInput;
+
+  /** @default "digital" */
+  style?: "digital" | "long" | "short" | "narrow";
+
+  /** @default "en" */
+  locale?: string;
+
+  /** @default true */
+  live?: boolean | number;
+
+  /** Called once, when the countdown reaches `to`. */
+  oncomplete?: () => void;
+
+  /**
+   * Snippet rendered inside the `time` element instead of the plain
+   * formatted string. Receives the formatted value and whether the
+   * countdown has completed.
+   */
+  children?: Snippet<[string, boolean]>;
+}
+
+declare const Countdown: Component<CountdownProps>;
+
+export default Countdown;

--- a/src/intl/Stopwatch.svelte
+++ b/src/intl/Stopwatch.svelte
@@ -1,0 +1,104 @@
+<script>
+  const {
+    /** Start instant to count elapsed time from. Captured once at mount
+     * as "now" when omitted. Changing `since` resets the stopwatch.
+     * @type {import("./format").TimeInput | undefined} */
+    since = undefined,
+
+    /** Set to `false` to pause (freezes the displayed value); back to
+     * `true` to resume — the paused interval is excluded.
+     * @type {boolean} */
+    running = true,
+
+    /** @type {"digital" | "long" | "short" | "narrow"} */
+    style = "digital",
+
+    /** @type {string} */
+    locale = "en",
+
+    /** Set to `true` to tick every second. Pass a number (ms) for a
+     * custom fixed interval. Only applies while `running` is `true`.
+     * @type {boolean | number} */
+    live = true,
+
+    /** @type {import("svelte").Snippet<[string, boolean]> | undefined} */
+    children,
+    ...rest
+  } = $props();
+
+  import { untrack } from "svelte";
+  import { formatDuration, toISODuration } from "./format";
+  import { sharedNow } from "./ticker";
+
+  const canTick = typeof document !== "undefined";
+
+  let anchor = $state(
+    untrack(() => (since === undefined ? new Date() : new Date(since))),
+  );
+
+  let pausedMs = $state(0);
+  let pausedAt = $state(/** @type {Date | undefined} */ (undefined));
+
+  $effect(() => {
+    if (since !== undefined) {
+      anchor = new Date(since);
+      pausedMs = 0;
+      pausedAt = untrack(() => running) ? undefined : new Date();
+    }
+  });
+
+  $effect(() => {
+    if (running) {
+      if (pausedAt !== undefined) {
+        pausedMs += Date.now() - pausedAt.getTime();
+        pausedAt = undefined;
+      }
+    } else if (pausedAt === undefined) {
+      pausedAt = new Date();
+    }
+  });
+
+  const effectiveInterval = $derived(
+    typeof live === "number" ? Math.abs(live) : 1_000,
+  );
+
+  const now = $derived(
+    running && live !== false && canTick
+      ? sharedNow(effectiveInterval)
+      : new Date(),
+  );
+
+  const elapsedMs = $derived(
+    Math.max(
+      0,
+      now.getTime() -
+        anchor.getTime() -
+        pausedMs -
+        (pausedAt ? now.getTime() - pausedAt.getTime() : 0),
+    ),
+  );
+
+  const formatted = $derived(
+    formatDuration(elapsedMs, {
+      locale,
+      style: /** @type {"digital" | "long" | "short" | "narrow"} */ (style),
+    }),
+  );
+  const datetime = $derived(toISODuration(elapsedMs));
+</script>
+
+{#if children}
+  <time
+    {datetime}
+    {...rest}
+  >
+    {@render children(formatted, running)}
+  </time>
+{:else}
+  <time
+    {datetime}
+    {...rest}
+  >
+    {formatted}
+  </time>
+{/if}

--- a/src/intl/Stopwatch.svelte.d.ts
+++ b/src/intl/Stopwatch.svelte.d.ts
@@ -1,0 +1,38 @@
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { TimeInput } from "./format";
+
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
+
+export interface StopwatchProps extends RestProps {
+  /** Start instant to count elapsed time from. Captured once at mount
+   * as "now" when omitted. Changing `since` resets the stopwatch.
+   * @default undefined
+   */
+  since?: TimeInput;
+
+  /** Set to `false` to pause; back to `true` to resume.
+   * @default true
+   */
+  running?: boolean;
+
+  /** @default "digital" */
+  style?: "digital" | "long" | "short" | "narrow";
+
+  /** @default "en" */
+  locale?: string;
+
+  /** @default true */
+  live?: boolean | number;
+
+  /**
+   * Snippet rendered inside the `time` element instead of the plain
+   * formatted string. Receives the formatted value and the current
+   * `running` state.
+   */
+  children?: Snippet<[string, boolean]>;
+}
+
+declare const Stopwatch: Component<StopwatchProps>;
+
+export default Stopwatch;

--- a/src/intl/Time.svelte
+++ b/src/intl/Time.svelte
@@ -1,0 +1,75 @@
+<script>
+  const {
+    /** @type {import("./format").TimeInput} */
+    timestamp = new Date().toISOString(),
+
+    /** Passed to `Intl.DateTimeFormat`. Defaults to `{ dateStyle: "medium" }`.
+     * @type {Intl.DateTimeFormatOptions} */
+    options = {},
+
+    /** @type {boolean} */
+    relative = false,
+
+    /** @type {"always" | "auto"} */
+    numeric = "auto",
+
+    /** Set to `true` (or a ms interval) to keep `relative` output live.
+     * @type {boolean | number} */
+    live = false,
+
+    /** @type {string} */
+    locale = "en",
+
+    /** @type {import("svelte").Snippet<[string]> | undefined} */
+    children,
+    ...rest
+  } = $props();
+
+  import { formatTime, relativeTime } from "./format";
+  import { sharedNow } from "./ticker";
+
+  const canTick = typeof document !== "undefined";
+
+  const now = $derived(
+    relative && live !== false && canTick
+      ? sharedNow(Math.abs(typeof live === "number" ? live : 60_000))
+      : new Date(),
+  );
+
+  const formatted = $derived(
+    relative
+      ? relativeTime(timestamp, {
+          locale,
+          from: now,
+          numeric: /** @type {"always" | "auto"} */ (numeric),
+        })
+      : formatTime(timestamp, { locale, ...options }),
+  );
+
+  const title = $derived(
+    relative ? formatTime(timestamp, { locale, ...options }) : undefined,
+  );
+
+  const datetime = $derived.by(() => {
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+  });
+</script>
+
+{#if children}
+  <time
+    {title}
+    {...rest}
+    {datetime}
+  >
+    {@render children(formatted)}
+  </time>
+{:else}
+  <time
+    {title}
+    {...rest}
+    {datetime}
+  >
+    {formatted}
+  </time>
+{/if}

--- a/src/intl/Time.svelte.d.ts
+++ b/src/intl/Time.svelte.d.ts
@@ -1,0 +1,31 @@
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { TimeInput } from "./format";
+
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
+
+export interface TimeProps extends RestProps {
+  /** @default new Date().toISOString() */
+  timestamp?: TimeInput;
+
+  /** Passed to `Intl.DateTimeFormat`. Defaults to `{ dateStyle: "medium" }`. */
+  options?: Intl.DateTimeFormatOptions;
+
+  /** @default false */
+  relative?: boolean;
+
+  /** Only applies when `relative` is `true`. @default "auto" */
+  numeric?: "always" | "auto";
+
+  /** @default false */
+  live?: boolean | number;
+
+  /** @default "en" */
+  locale?: string;
+
+  children?: Snippet<[string]>;
+}
+
+declare const Time: Component<TimeProps>;
+
+export default Time;

--- a/src/intl/TimeRange.svelte
+++ b/src/intl/TimeRange.svelte
@@ -1,0 +1,53 @@
+<script>
+  const {
+    /** Start instant of the range.
+     * @type {import("./format").TimeInput} */
+    start,
+
+    /** End instant of the range.
+     * @type {import("./format").TimeInput} */
+    end,
+
+    /** @type {Intl.DateTimeFormatOptions} */
+    options = {},
+
+    /** @type {string} */
+    locale = "en",
+
+    /** @type {import("svelte").Snippet<[string]> | undefined} */
+    children,
+    ...rest
+  } = $props();
+
+  import { formatRange } from "./format";
+
+  const formatted = $derived(formatRange(start, end, { locale, ...options }));
+
+  // ISO 8601 interval notation (RFC — start/end), since a single instant
+  // can't represent a range; unlike the main package's two-<time>-element
+  // `TimeRange`, this renders one element with the native condensed text.
+  const datetime = $derived.by(() => {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      return undefined;
+    }
+    return `${startDate.toISOString()}/${endDate.toISOString()}`;
+  });
+</script>
+
+{#if children}
+  <time
+    {datetime}
+    {...rest}
+  >
+    {@render children(formatted)}
+  </time>
+{:else}
+  <time
+    {datetime}
+    {...rest}
+  >
+    {formatted}
+  </time>
+{/if}

--- a/src/intl/TimeRange.svelte.d.ts
+++ b/src/intl/TimeRange.svelte.d.ts
@@ -1,0 +1,25 @@
+import type { Component, Snippet } from "svelte";
+import type { SvelteHTMLElements } from "svelte/elements";
+import type { TimeInput } from "./format";
+
+type RestProps = Omit<SvelteHTMLElements["time"], "children">;
+
+export interface TimeRangeProps extends RestProps {
+  /** Start instant of the range. */
+  start: TimeInput;
+
+  /** End instant of the range. */
+  end: TimeInput;
+
+  /** Passed to `Intl.DateTimeFormat`. Defaults to `{ dateStyle: "medium" }`. */
+  options?: Intl.DateTimeFormatOptions;
+
+  /** @default "en" */
+  locale?: string;
+
+  children?: Snippet<[string]>;
+}
+
+declare const TimeRange: Component<TimeRangeProps>;
+
+export default TimeRange;

--- a/src/intl/attachment.js
+++ b/src/intl/attachment.js
@@ -1,0 +1,192 @@
+import {
+  formatDuration,
+  formatRange,
+  formatTime,
+  relativeTime,
+  toISODuration,
+} from "./format";
+import { sharedNow } from "./ticker";
+
+/**
+ * Attachment version of `svelteTime` (intl). Options are reactive: the
+ * attachment re-runs when any reactive value used to build `options`
+ * changes, and live mode subscribes to the shared ticker.
+ * @param {Partial<import("./svelte-time.svelte").SvelteTimeOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach time({ relative: true, timestamp })}></time>
+ */
+export function time(options = {}) {
+  return (node) => {
+    const timestamp = options.timestamp ?? new Date().toISOString();
+    const locale = options.locale ?? "en";
+    const relative = options.relative === true;
+    const numeric = options.numeric ?? "auto";
+    const dtOptions = options.options ?? {};
+    const live = options.live ?? false;
+
+    let now = new Date();
+    if (relative && live !== false) {
+      // Reading sharedNow subscribes this attachment to the shared
+      // clock; each tick re-runs the whole attachment.
+      now = sharedNow(Math.abs(typeof live === "number" ? live : 60_000));
+    }
+
+    if (relative) {
+      node.setAttribute(
+        "title",
+        formatTime(timestamp, { locale, ...dtOptions }),
+      );
+    } else {
+      node.removeAttribute("title");
+    }
+
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) node.removeAttribute("datetime");
+    else node.setAttribute("datetime", date.toISOString());
+
+    node.textContent = relative
+      ? relativeTime(timestamp, { locale, numeric, from: now })
+      : formatTime(timestamp, { locale, ...dtOptions });
+  };
+}
+
+/**
+ * Attachment version of `svelteTimeRange`.
+ * @param {Partial<import("./svelte-time-range.svelte").SvelteTimeRangeOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach timeRange({ start, end })}></time>
+ */
+export function timeRange(options = {}) {
+  return (node) => {
+    const {
+      start = "",
+      end = "",
+      locale = "en",
+      options: dtOptions = {},
+    } = options;
+
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (
+      !Number.isNaN(startDate.getTime()) &&
+      !Number.isNaN(endDate.getTime())
+    ) {
+      node.setAttribute(
+        "datetime",
+        `${startDate.toISOString()}/${endDate.toISOString()}`,
+      );
+    } else {
+      node.removeAttribute("datetime");
+    }
+
+    node.textContent = formatRange(start, end, { locale, ...dtOptions });
+  };
+}
+
+/**
+ * Attachment version of `svelteCountdown`.
+ * @param {Partial<import("./svelte-countdown.svelte").SvelteCountdownOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach countdown({ to: target, oncomplete: () => {} })}></time>
+ */
+export function countdown(options = {}) {
+  let completed = false;
+
+  return (node) => {
+    const to = options.to ?? "";
+    const style = options.style ?? "digital";
+    const locale = options.locale ?? "en";
+    const live = options.live ?? true;
+
+    let now = new Date();
+    if (live !== false && !completed) {
+      const interval = typeof live === "number" ? Math.abs(live) : 1_000;
+      now = sharedNow(interval);
+    }
+
+    const remainingMs = Math.max(0, new Date(to).getTime() - now.getTime());
+
+    node.setAttribute("datetime", toISODuration(remainingMs));
+    node.textContent = formatDuration(remainingMs, { locale, style });
+
+    if (remainingMs === 0 && !completed) {
+      completed = true;
+      options.oncomplete?.();
+    }
+  };
+}
+
+/**
+ * Per-node pause/resume bookkeeping for the `stopwatch` attachment,
+ * keyed by the attached DOM node — mirrors the main package's approach,
+ * since the outer factory is re-invoked fresh whenever `running` changes.
+ * @type {WeakMap<HTMLElement, { anchor: undefined | Date, pausedMs: number, pausedAt: undefined | Date, prevSince: undefined | import("./format").TimeInput, prevRunning: boolean }>}
+ */
+const stopwatchStateByNode = new WeakMap();
+
+/**
+ * Attachment version of `svelteStopwatch`.
+ * @param {Partial<import("./svelte-stopwatch.svelte").SvelteStopwatchOptions>} [options]
+ * @returns {(node: HTMLElement) => void}
+ * @example <time {@attach stopwatch({ since: startedAt, running })}></time>
+ */
+export function stopwatch(options = {}) {
+  return (node) => {
+    let state = stopwatchStateByNode.get(node);
+    if (!state) {
+      state = {
+        anchor: undefined,
+        pausedMs: 0,
+        pausedAt: undefined,
+        prevSince: undefined,
+        prevRunning: true,
+      };
+      stopwatchStateByNode.set(node, state);
+    }
+
+    const since = options.since;
+    const running = options.running ?? true;
+    const style = options.style ?? "digital";
+    const locale = options.locale ?? "en";
+    const live = options.live ?? true;
+
+    if (
+      state.anchor === undefined ||
+      (since !== undefined && since !== state.prevSince)
+    ) {
+      state.anchor =
+        since === undefined ? (state.anchor ?? new Date()) : new Date(since);
+      state.pausedMs = 0;
+      state.pausedAt = running ? undefined : new Date();
+    } else if (running !== state.prevRunning) {
+      if (running) {
+        if (state.pausedAt !== undefined) {
+          state.pausedMs += Date.now() - state.pausedAt.getTime();
+          state.pausedAt = undefined;
+        }
+      } else if (state.pausedAt === undefined) {
+        state.pausedAt = new Date();
+      }
+    }
+
+    state.prevSince = since;
+    state.prevRunning = running;
+
+    let now = new Date();
+    if (running && live !== false) {
+      const interval = typeof live === "number" ? Math.abs(live) : 1_000;
+      now = sharedNow(interval);
+    }
+
+    const elapsedMs = Math.max(
+      0,
+      now.getTime() -
+        state.anchor.getTime() -
+        state.pausedMs -
+        (state.pausedAt ? now.getTime() - state.pausedAt.getTime() : 0),
+    );
+
+    node.setAttribute("datetime", toISODuration(elapsedMs));
+    node.textContent = formatDuration(elapsedMs, { locale, style });
+  };
+}

--- a/src/intl/format.js
+++ b/src/intl/format.js
@@ -1,0 +1,116 @@
+// Zero-dependency by design — do not import dayjs (or anything else) here.
+// This is what makes `svelte-time/intl` a separate, dep-free entry point.
+
+/** @typedef {Date | number | string} TimeInput */
+
+/**
+ * Format a timestamp using `Intl.DateTimeFormat`. Defaults to
+ * `{ dateStyle: "medium" }` when no field/style options are given.
+ * @param {TimeInput} timestamp
+ * @param {Intl.DateTimeFormatOptions & { locale?: string }} [options]
+ * @returns {string}
+ */
+export function formatTime(timestamp, options = {}) {
+  const { locale = "en", ...rest } = options;
+  /** @type {Intl.DateTimeFormatOptions} */
+  const dtOptions = Object.keys(rest).length ? rest : { dateStyle: "medium" };
+  return new Intl.DateTimeFormat(locale, dtOptions).format(new Date(timestamp));
+}
+
+/**
+ * Format a date range using `Intl.DateTimeFormat.prototype.formatRange`,
+ * e.g. "Jan 10 – 15, 2026". Defaults to `{ dateStyle: "medium" }`.
+ * @param {TimeInput} start
+ * @param {TimeInput} end
+ * @param {Intl.DateTimeFormatOptions & { locale?: string }} [options]
+ * @returns {string}
+ */
+export function formatRange(start, end, options = {}) {
+  const { locale = "en", ...rest } = options;
+  /** @type {Intl.DateTimeFormatOptions} */
+  const dtOptions = Object.keys(rest).length ? rest : { dateStyle: "medium" };
+  return new Intl.DateTimeFormat(locale, dtOptions).formatRange(
+    new Date(start),
+    new Date(end),
+  );
+}
+
+/** Largest-to-smallest; picks the first unit `diffMs` is at least one of. */
+const RELATIVE_UNITS = /** @type {const} */ ([
+  ["year", 31536000000],
+  ["month", 2628000000],
+  ["week", 604800000],
+  ["day", 86400000],
+  ["hour", 3600000],
+  ["minute", 60000],
+  ["second", 1000],
+]);
+
+/**
+ * Relative time string via `Intl.RelativeTimeFormat`, e.g. "4 days ago".
+ * `from` sets the reference point (defaults to now).
+ * @param {TimeInput} timestamp
+ * @param {{ locale?: string, numeric?: "always" | "auto", from?: TimeInput }} [options]
+ * @returns {string}
+ */
+export function relativeTime(timestamp, options = {}) {
+  const { locale = "en", numeric = "auto", from = new Date() } = options;
+  const diffMs = new Date(timestamp).getTime() - new Date(from).getTime();
+  const abs = Math.abs(diffMs);
+  const [unit, unitMs] =
+    RELATIVE_UNITS.find(([, ms]) => abs >= ms) ??
+    RELATIVE_UNITS[RELATIVE_UNITS.length - 1];
+  return new Intl.RelativeTimeFormat(locale, { numeric }).format(
+    Math.round(diffMs / unitMs),
+    unit,
+  );
+}
+
+/**
+ * Format a millisecond duration via `Intl.DurationFormat` (hours/minutes/
+ * seconds only — good enough for stopwatch/countdown display; pass
+ * `style: "long"` etc. for humanized output).
+ * @param {number} ms
+ * @param {{ locale?: string, style?: "long" | "short" | "narrow" | "digital" }} [options]
+ * @returns {string}
+ */
+export function formatDuration(ms, options = {}) {
+  const { locale = "en", style = "digital" } = options;
+  const negative = ms < 0;
+  let remaining = Math.abs(Math.round(ms));
+  const hours = Math.floor(remaining / 3600000);
+  remaining -= hours * 3600000;
+  const minutes = Math.floor(remaining / 60000);
+  remaining -= minutes * 60000;
+  const seconds = Math.floor(remaining / 1000);
+
+  const formatted = new Intl.DurationFormat(locale, { style }).format({
+    hours,
+    minutes,
+    seconds,
+  });
+  return negative ? `-${formatted}` : formatted;
+}
+
+/**
+ * ISO 8601 duration string for a millisecond span (e.g. "PT1H30M25S"),
+ * for use as a `<time datetime>` value alongside `formatDuration`'s
+ * human-readable text.
+ * @param {number} ms
+ * @returns {string}
+ */
+export function toISODuration(ms) {
+  const negative = ms < 0;
+  let remaining = Math.abs(Math.round(ms));
+  const hours = Math.floor(remaining / 3600000);
+  remaining -= hours * 3600000;
+  const minutes = Math.floor(remaining / 60000);
+  remaining -= minutes * 60000;
+  const seconds = Math.floor(remaining / 1000);
+
+  let iso = "PT";
+  if (hours) iso += `${hours}H`;
+  if (minutes) iso += `${minutes}M`;
+  iso += `${seconds}S`;
+  return negative ? `-${iso}` : iso;
+}

--- a/src/intl/index.js
+++ b/src/intl/index.js
@@ -1,0 +1,16 @@
+export { countdown, stopwatch, time, timeRange } from "./attachment";
+export { default as Countdown } from "./Countdown.svelte";
+export {
+  formatDuration,
+  formatRange,
+  formatTime,
+  relativeTime,
+  toISODuration,
+} from "./format";
+export { default as Stopwatch } from "./Stopwatch.svelte";
+export { svelteCountdown } from "./svelte-countdown.svelte";
+export { svelteStopwatch } from "./svelte-stopwatch.svelte";
+export { svelteTime } from "./svelte-time.svelte";
+export { svelteTimeRange } from "./svelte-time-range.svelte";
+export { default as Time } from "./Time.svelte";
+export { default as TimeRange } from "./TimeRange.svelte";

--- a/src/intl/svelte-countdown.svelte.d.ts
+++ b/src/intl/svelte-countdown.svelte.d.ts
@@ -1,0 +1,13 @@
+import type { Action } from "svelte/action";
+import type { CountdownProps } from "./Countdown.svelte";
+
+export interface SvelteCountdownOptions
+  extends Pick<
+    CountdownProps,
+    "to" | "style" | "locale" | "live" | "oncomplete"
+  > {}
+
+export const svelteCountdown: Action<
+  HTMLElement,
+  undefined | Partial<SvelteCountdownOptions>
+>;

--- a/src/intl/svelte-countdown.svelte.js
+++ b/src/intl/svelte-countdown.svelte.js
@@ -1,0 +1,73 @@
+import { formatDuration, toISODuration } from "./format";
+
+const DEFAULT_INTERVAL = 1_000;
+
+/**
+ * @typedef {object} SvelteCountdownOptions
+ * @property {import("./format").TimeInput} to
+ * @property {"digital" | "long" | "short" | "narrow"} style
+ * @property {string} locale
+ * @property {boolean | number} live
+ * @property {() => void} oncomplete
+ */
+
+/**
+ * Action version of `Countdown.svelte`.
+ * @type {import("svelte/action").Action<HTMLElement, Partial<SvelteCountdownOptions>>}
+ */
+export const svelteCountdown = (node, options = {}) => {
+  /** @type {undefined | ReturnType<typeof setInterval>} */
+  let interval;
+  let completed = false;
+  /** @type {undefined | import("./format").TimeInput} */
+  let lastTo;
+
+  /** @param {Partial<SvelteCountdownOptions>} [options] */
+  const render = (options = {}) => {
+    const to = options.to;
+    const style = options.style ?? "digital";
+    const locale = options.locale ?? "en";
+
+    const remainingMs = Math.max(0, new Date(to ?? "").getTime() - Date.now());
+
+    node.setAttribute("datetime", toISODuration(remainingMs));
+    node.textContent = formatDuration(remainingMs, { locale, style });
+
+    if (remainingMs === 0 && !completed) {
+      completed = true;
+      clearInterval(interval);
+      interval = undefined;
+      options.oncomplete?.();
+    }
+  };
+
+  /** @param {Partial<SvelteCountdownOptions>} [options] */
+  const updateCountdown = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+
+    if (options.to !== lastTo) {
+      completed = false;
+      lastTo = options.to;
+    }
+
+    render(options);
+
+    const live = options.live ?? true;
+    if (live !== false && !completed) {
+      interval = setInterval(
+        () => render(options),
+        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
+      );
+    }
+  };
+
+  updateCountdown(options);
+
+  return {
+    update: updateCountdown,
+    destroy() {
+      clearInterval(interval);
+    },
+  };
+};

--- a/src/intl/svelte-stopwatch.svelte.d.ts
+++ b/src/intl/svelte-stopwatch.svelte.d.ts
@@ -1,0 +1,13 @@
+import type { Action } from "svelte/action";
+import type { StopwatchProps } from "./Stopwatch.svelte";
+
+export interface SvelteStopwatchOptions
+  extends Pick<
+    StopwatchProps,
+    "since" | "running" | "style" | "locale" | "live"
+  > {}
+
+export const svelteStopwatch: Action<
+  HTMLElement,
+  undefined | Partial<SvelteStopwatchOptions>
+>;

--- a/src/intl/svelte-stopwatch.svelte.js
+++ b/src/intl/svelte-stopwatch.svelte.js
@@ -1,0 +1,94 @@
+import { formatDuration, toISODuration } from "./format";
+
+const DEFAULT_INTERVAL = 1_000;
+
+/**
+ * @typedef {object} SvelteStopwatchOptions
+ * @property {import("./format").TimeInput} since
+ * @property {boolean} running
+ * @property {"digital" | "long" | "short" | "narrow"} style
+ * @property {string} locale
+ * @property {boolean | number} live
+ */
+
+/**
+ * Action version of `Stopwatch.svelte`.
+ * @type {import("svelte/action").Action<HTMLElement, Partial<SvelteStopwatchOptions>>}
+ */
+export const svelteStopwatch = (node, options = {}) => {
+  /** @type {undefined | ReturnType<typeof setInterval>} */
+  let interval;
+
+  /** @type {undefined | Date} */
+  let anchor;
+  let pausedMs = 0;
+  /** @type {undefined | Date} */
+  let pausedAt;
+  /** @type {undefined | import("./format").TimeInput} */
+  let prevSince;
+  let prevRunning = true;
+
+  /** @param {Partial<SvelteStopwatchOptions>} [options] */
+  const render = (options = {}) => {
+    const style = options.style ?? "digital";
+    const locale = options.locale ?? "en";
+
+    const now = new Date();
+    const elapsedMs = Math.max(
+      0,
+      now.getTime() -
+        /** @type {Date} */ (anchor).getTime() -
+        pausedMs -
+        (pausedAt ? now.getTime() - pausedAt.getTime() : 0),
+    );
+
+    node.setAttribute("datetime", toISODuration(elapsedMs));
+    node.textContent = formatDuration(elapsedMs, { locale, style });
+  };
+
+  /** @param {Partial<SvelteStopwatchOptions>} [options] */
+  const updateStopwatch = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+
+    const since = options.since;
+    const running = options.running ?? true;
+
+    if (anchor === undefined || (since !== undefined && since !== prevSince)) {
+      anchor = since === undefined ? (anchor ?? new Date()) : new Date(since);
+      pausedMs = 0;
+      pausedAt = running ? undefined : new Date();
+    } else if (running !== prevRunning) {
+      if (running) {
+        if (pausedAt !== undefined) {
+          pausedMs += Date.now() - pausedAt.getTime();
+          pausedAt = undefined;
+        }
+      } else if (pausedAt === undefined) {
+        pausedAt = new Date();
+      }
+    }
+
+    prevSince = since;
+    prevRunning = running;
+
+    render(options);
+
+    const live = options.live ?? true;
+    if (running && live !== false) {
+      interval = setInterval(
+        () => render(options),
+        Math.abs(typeof live === "number" ? live : DEFAULT_INTERVAL),
+      );
+    }
+  };
+
+  updateStopwatch(options);
+
+  return {
+    update: updateStopwatch,
+    destroy() {
+      clearInterval(interval);
+    },
+  };
+};

--- a/src/intl/svelte-time-range.svelte.d.ts
+++ b/src/intl/svelte-time-range.svelte.d.ts
@@ -1,0 +1,10 @@
+import type { Action } from "svelte/action";
+import type { TimeRangeProps } from "./TimeRange.svelte";
+
+export interface SvelteTimeRangeOptions
+  extends Pick<TimeRangeProps, "start" | "end" | "options" | "locale"> {}
+
+export const svelteTimeRange: Action<
+  HTMLElement,
+  undefined | Partial<SvelteTimeRangeOptions>
+>;

--- a/src/intl/svelte-time-range.svelte.js
+++ b/src/intl/svelte-time-range.svelte.js
@@ -1,0 +1,46 @@
+import { formatRange } from "./format";
+
+/**
+ * @typedef {object} SvelteTimeRangeOptions
+ * @property {import("./format").TimeInput} start
+ * @property {import("./format").TimeInput} end
+ * @property {Intl.DateTimeFormatOptions} options
+ * @property {string} locale
+ */
+
+/**
+ * Action version of `TimeRange.svelte`.
+ * @type {import("svelte/action").Action<HTMLElement, Partial<SvelteTimeRangeOptions>>}
+ */
+export const svelteTimeRange = (node, options = {}) => {
+  const updateTimeRange = (
+    /** @type {Partial<SvelteTimeRangeOptions>} */ options = {},
+  ) => {
+    const {
+      start = "",
+      end = "",
+      locale = "en",
+      options: dtOptions = {},
+    } = options;
+
+    const startDate = new Date(start ?? "");
+    const endDate = new Date(end ?? "");
+    if (
+      !Number.isNaN(startDate.getTime()) &&
+      !Number.isNaN(endDate.getTime())
+    ) {
+      node.setAttribute(
+        "datetime",
+        `${startDate.toISOString()}/${endDate.toISOString()}`,
+      );
+    } else {
+      node.removeAttribute("datetime");
+    }
+
+    node.textContent = formatRange(start, end, { locale, ...dtOptions });
+  };
+
+  updateTimeRange(options);
+
+  return { update: updateTimeRange };
+};

--- a/src/intl/svelte-time.svelte.d.ts
+++ b/src/intl/svelte-time.svelte.d.ts
@@ -1,0 +1,13 @@
+import type { Action } from "svelte/action";
+import type { TimeProps } from "./Time.svelte";
+
+export interface SvelteTimeOptions
+  extends Pick<
+    TimeProps,
+    "timestamp" | "options" | "relative" | "numeric" | "live" | "locale"
+  > {}
+
+export const svelteTime: Action<
+  HTMLElement,
+  undefined | Partial<SvelteTimeOptions>
+>;

--- a/src/intl/svelte-time.svelte.js
+++ b/src/intl/svelte-time.svelte.js
@@ -1,0 +1,74 @@
+import { formatTime, relativeTime } from "./format";
+
+/**
+ * @typedef {object} SvelteTimeOptions
+ * @property {import("./format").TimeInput} timestamp
+ * @property {Intl.DateTimeFormatOptions} options
+ * @property {boolean} relative
+ * @property {"always" | "auto"} numeric
+ * @property {boolean | number} live
+ * @property {string} locale
+ */
+
+/**
+ * Action version of `Time.svelte`, backed by `Intl.DateTimeFormat` /
+ * `Intl.RelativeTimeFormat` instead of dayjs.
+ * @type {import("svelte/action").Action<HTMLElement, Partial<SvelteTimeOptions>>}
+ */
+export const svelteTime = (node, options = {}) => {
+  /** @type {undefined | ReturnType<typeof setInterval>} */
+  let interval;
+
+  /** @param {Partial<SvelteTimeOptions>} [options] */
+  const updateTime = (options = {}) => {
+    clearInterval(interval);
+    interval = undefined;
+
+    const timestamp = options.timestamp ?? new Date().toISOString();
+    const locale = options.locale ?? "en";
+    const relative = options.relative === true;
+    const numeric = options.numeric ?? "auto";
+    const dtOptions = options.options ?? {};
+    const live = options.live ?? false;
+
+    const render = () => {
+      node.textContent = relative
+        ? relativeTime(timestamp, { locale, numeric })
+        : formatTime(timestamp, { locale, ...dtOptions });
+
+      if (relative) {
+        node.setAttribute(
+          "title",
+          formatTime(timestamp, { locale, ...dtOptions }),
+        );
+      } else {
+        node.removeAttribute("title");
+      }
+
+      const date = new Date(timestamp);
+      if (Number.isNaN(date.getTime())) {
+        node.removeAttribute("datetime");
+      } else {
+        node.setAttribute("datetime", date.toISOString());
+      }
+    };
+
+    render();
+
+    if (relative && live !== false) {
+      interval = setInterval(
+        render,
+        Math.abs(typeof live === "number" ? live : 60_000),
+      );
+    }
+  };
+
+  updateTime(options);
+
+  return {
+    update: updateTime,
+    destroy() {
+      clearInterval(interval);
+    },
+  };
+};

--- a/src/intl/ticker.js
+++ b/src/intl/ticker.js
@@ -1,0 +1,53 @@
+import { createSubscriber } from "svelte/reactivity";
+
+/**
+ * One shared timer per distinct interval (ms), active only while
+ * subscribed. Same pattern as `../ticker.js`, but backed by plain `Date`
+ * instead of dayjs, to keep this subpackage dependency-free.
+ */
+const tickers = new Map();
+
+/**
+ * Reactive "now". When read inside an effect or derived, the caller
+ * re-runs on every tick of the shared timer for `intervalMs`.
+ * @param {number} intervalMs
+ * @returns {Date}
+ */
+export function sharedNow(intervalMs) {
+  let read = tickers.get(intervalMs);
+  if (!read) {
+    let now = new Date();
+    const subscribe = createSubscriber((update) => {
+      now = new Date();
+      const id = setInterval(() => {
+        now = new Date();
+        update();
+      }, intervalMs);
+
+      /** @type {(() => void) | undefined} */
+      let onVisibilityChange;
+      if (typeof document !== "undefined") {
+        onVisibilityChange = () => {
+          if (!document.hidden) {
+            now = new Date();
+            update();
+          }
+        };
+        document.addEventListener("visibilitychange", onVisibilityChange);
+      }
+
+      return () => {
+        clearInterval(id);
+        if (onVisibilityChange) {
+          document.removeEventListener("visibilitychange", onVisibilityChange);
+        }
+      };
+    });
+    read = () => {
+      subscribe();
+      return now;
+    };
+    tickers.set(intervalMs, read);
+  }
+  return read();
+}

--- a/tests/examples/IntlBasic.svelte
+++ b/tests/examples/IntlBasic.svelte
@@ -1,0 +1,5 @@
+<script>
+  import { Time } from "svelte-time/intl";
+</script>
+
+<Time />

--- a/tests/examples/IntlCalendar.svelte
+++ b/tests/examples/IntlCalendar.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { Time } from "svelte-time/intl";
+
+  const timestamp = new Date();
+</script>
+
+<!-- Alternate calendar systems, no plugins required -->
+<Time
+  {timestamp}
+  options={{ dateStyle: "long", calendar: "japanese" }}
+/>
+<Time
+  {timestamp}
+  options={{ dateStyle: "long", calendar: "islamic" }}
+/>
+<Time
+  {timestamp}
+  options={{ dateStyle: "long", calendar: "buddhist" }}
+/>
+
+<!-- Alternate numbering system -->
+<Time
+  {timestamp}
+  options={{ dateStyle: "long", numberingSystem: "arab" }}
+/>

--- a/tests/examples/IntlCountdownBasic.svelte
+++ b/tests/examples/IntlCountdownBasic.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { Countdown } from "svelte-time/intl";
+
+  let to = $state(new Date(Date.now() + 20_000));
+</script>
+
+<!-- Ticks live by default, once per second -->
+<Countdown {to} />
+
+<!-- style="long" gives a humanized readout -->
+<Countdown
+  {to}
+  style="long"
+/>
+
+<!-- Changing `to` restarts the countdown -->
+<button
+  type="button"
+  onclick={() => (to = new Date(Date.now() + 20_000))}
+>
+  Reset
+</button>

--- a/tests/examples/IntlCountdownOnComplete.svelte
+++ b/tests/examples/IntlCountdownOnComplete.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { Countdown } from "svelte-time/intl";
+
+  let to = $state(new Date(Date.now() + 5000));
+</script>
+
+<Countdown
+  {to}
+  oncomplete={() => console.log("done!")}
+>
+  {#snippet children(formatted, done)}
+    {done ? "Done!" : formatted}
+  {/snippet}
+</Countdown>

--- a/tests/examples/IntlCustomOptions.svelte
+++ b/tests/examples/IntlCustomOptions.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { Time } from "svelte-time/intl";
+</script>
+
+<Time
+  timestamp="2020-02-01"
+  options={{ weekday: "long", year: "numeric", month: "short", day: "numeric" }}
+/>
+
+<Time
+  timestamp={new Date()}
+  options={{ year: "numeric", month: "2-digit", day: "2-digit" }}
+/>

--- a/tests/examples/IntlDateStyle.svelte
+++ b/tests/examples/IntlDateStyle.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Time } from "svelte-time/intl";
+
+  const timestamp = new Date();
+</script>
+
+<Time
+  {timestamp}
+  options={{ dateStyle: "short" }}
+/>
+<Time
+  {timestamp}
+  options={{ dateStyle: "full" }}
+/>
+<Time
+  {timestamp}
+  options={{ dateStyle: "medium", timeStyle: "short" }}
+/>

--- a/tests/examples/IntlDuration.svelte
+++ b/tests/examples/IntlDuration.svelte
@@ -1,0 +1,10 @@
+<script>
+  import { formatDuration } from "svelte-time/intl";
+
+  const ms = 5_425_000; // 1h 30m 25s
+</script>
+
+<p>digital (default): {formatDuration(ms)}</p>
+<p>long: {formatDuration(ms, { style: "long" })}</p>
+<p>narrow: {formatDuration(ms, { style: "narrow" })}</p>
+<p>negative: {formatDuration(-42_000)}</p>

--- a/tests/examples/IntlLive.svelte
+++ b/tests/examples/IntlLive.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { Time } from "svelte-time/intl";
+
+  const timestamp = new Date();
+</script>
+
+<Time
+  relative
+  live
+  {timestamp}
+/>

--- a/tests/examples/IntlLocale.svelte
+++ b/tests/examples/IntlLocale.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { Time } from "svelte-time/intl";
+
+  const timestamp = "2024-03-15T18:30:00Z";
+</script>
+
+<!-- No locale files to import — the browser/runtime's ICU data covers every BCP-47 locale -->
+<Time
+  {timestamp}
+  locale="de"
+  options={{ dateStyle: "long" }}
+/>
+<Time
+  {timestamp}
+  locale="ja"
+  options={{ dateStyle: "long" }}
+/>
+<Time
+  {timestamp}
+  locale="ar"
+  options={{ dateStyle: "long" }}
+/>
+<Time
+  relative
+  {timestamp}
+  locale="fr"
+/>

--- a/tests/examples/IntlRelative.svelte
+++ b/tests/examples/IntlRelative.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { Time } from "svelte-time/intl";
+</script>
+
+<Time
+  relative
+  timestamp={Date.now() - 4 * 86_400_000}
+/>
+<Time
+  relative
+  timestamp={Date.now() + 2 * 3_600_000}
+/>

--- a/tests/examples/IntlRelativeAlways.svelte
+++ b/tests/examples/IntlRelativeAlways.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { Time } from "svelte-time/intl";
+
+  const timestamp = Date.now() - 86_400_000;
+</script>
+
+<!-- numeric="auto" (default): "yesterday" -->
+<Time
+  relative
+  {timestamp}
+/>
+
+<!-- numeric="always": "1 day ago" -->
+<Time
+  relative
+  {timestamp}
+  numeric="always"
+/>

--- a/tests/examples/IntlStopwatchBasic.svelte
+++ b/tests/examples/IntlStopwatchBasic.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { Stopwatch } from "svelte-time/intl";
+
+  let since = $state(new Date());
+</script>
+
+<!-- Ticks live by default, once per second -->
+<Stopwatch {since} />
+
+<!-- Changing `since` restarts the stopwatch -->
+<button
+  type="button"
+  onclick={() => (since = new Date())}
+>
+  Restart
+</button>

--- a/tests/examples/IntlStopwatchPause.svelte
+++ b/tests/examples/IntlStopwatchPause.svelte
@@ -1,0 +1,23 @@
+<script>
+  import { Stopwatch } from "svelte-time/intl";
+
+  const since = new Date();
+  let running = $state(true);
+</script>
+
+<Stopwatch
+  {since}
+  {running}
+>
+  {#snippet children(formatted, isRunning)}
+    {formatted}
+    {isRunning ? "(running)" : "(paused)"}
+  {/snippet}
+</Stopwatch>
+
+<button
+  type="button"
+  onclick={() => (running = !running)}
+>
+  {running ? "Pause" : "Resume"}
+</button>

--- a/tests/examples/IntlSvelteTimeAction.svelte
+++ b/tests/examples/IntlSvelteTimeAction.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { svelteTime } from "svelte-time/intl";
+</script>
+
+<time use:svelteTime></time>
+
+<time
+  use:svelteTime={{
+    timestamp: "2021-02-02",
+    options: { dateStyle: "long" },
+  }}
+></time>
+
+<time
+  use:svelteTime={{ relative: true, timestamp: Date.now() - 4 * 86_400_000 }}
+></time>

--- a/tests/examples/IntlSvelteTimeRangeAction.svelte
+++ b/tests/examples/IntlSvelteTimeRangeAction.svelte
@@ -1,0 +1,5 @@
+<script>
+  import { svelteTimeRange } from "svelte-time/intl";
+</script>
+
+<time use:svelteTimeRange={{ start: "2026-01-10", end: "2026-01-15" }}></time>

--- a/tests/examples/IntlTimeAttachment.svelte
+++ b/tests/examples/IntlTimeAttachment.svelte
@@ -1,0 +1,8 @@
+<script>
+  // biome-ignore lint/correctness/noUnusedImports: `time` is used in the {@attach} directive below
+  import { time } from "svelte-time/intl";
+</script>
+
+<time
+  {@attach time({ timestamp: "2021-02-02", options: { dateStyle: "long" } })}
+></time>

--- a/tests/examples/IntlTimeRange.svelte
+++ b/tests/examples/IntlTimeRange.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { TimeRange } from "svelte-time/intl";
+</script>
+
+<!-- Output: "Jan 10 – 15, 2026" -->
+<TimeRange
+  start="2026-01-10"
+  end="2026-01-15"
+/>
+
+<!-- Spans months/years automatically -->
+<TimeRange
+  start="2026-01-10"
+  end="2026-03-02"
+/>
+
+<TimeRange
+  start="2026-01-10"
+  end="2026-01-15"
+  options={{ dateStyle: "long" }}
+/>

--- a/tests/examples/IntlTimeRangeAttachment.svelte
+++ b/tests/examples/IntlTimeRangeAttachment.svelte
@@ -1,0 +1,6 @@
+<script>
+  // biome-ignore lint/correctness/noUnusedImports: `timeRange` is used in the {@attach} directive below
+  import { timeRange } from "svelte-time/intl";
+</script>
+
+<time {@attach timeRange({ start: "2026-01-10", end: "2026-01-15" })}></time>

--- a/tests/examples/IntlUtilities.svelte
+++ b/tests/examples/IntlUtilities.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { formatRange, formatTime, relativeTime } from "svelte-time/intl";
+
+  const timestamp = "2026-01-10T00:00:00Z";
+</script>
+
+<ul>
+  <li>formatTime: {formatTime(timestamp)}</li>
+  <li>relativeTime: {relativeTime(timestamp)}</li>
+  <li>formatRange: {formatRange(timestamp, "2026-01-15T00:00:00Z")}</li>
+</ul>


### PR DESCRIPTION
Consumers who want locale-aware timestamps without shipping dayjs (and
its locale/plugin files) had no first-party option in svelte-time.
Native Intl APIs already cover absolute, relative, duration, and range
formatting in modern runtimes.

This adds a `svelte-time/intl` subpath that mirrors the existing
Time/TimeRange/Stopwatch/Countdown surface (component, action,
attachment) using `Intl.DateTimeFormat`, `RelativeTimeFormat`, and
`DurationFormat` instead of dayjs. The dayjs entry points are
unchanged; this ships alongside them, not instead of them.

## TimeRange design

Unlike the dayjs-based `TimeRange` (two `<time>` elements joined by a
separator, since one `datetime` attribute can't hold a range), the
intl version renders a single `<time>` element using
`Intl.DateTimeFormat`'s native `formatRange`, which condenses shared
date parts (e.g. "Jan 10 - 15, 2026"). Its `datetime` uses ISO 8601
interval notation (`start/end`) instead.

Risk: opt-in import path only, so existing dayjs consumers are
unaffected. Intl's output can differ from dayjs token formatting for
the same locale, it can't parse arbitrary date strings or do date
arithmetic, and `Intl.DurationFormat` is the newest of the three APIs
used here (Baseline since March 2025), less battle-tested than
`DateTimeFormat`/`RelativeTimeFormat`. The README states these
trade-offs directly rather than only in a comparison table.
