### PR TITLE
fix: break adaptive live interval loop at tier boundaries

### DIFF
--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -114,7 +114,12 @@
 
   $effect(() => {
     if (relative && live === true) {
-      const next = liveInterval(day.diff(now));
+      // Track `now` only to re-run on each tick of the shared clock; the
+      // tier decision itself uses a fresh, non-cached current time so it
+      // can't disagree with itself as `interval` switches which shared
+      // clock `now` reads from.
+      void now;
+      const next = liveInterval(day.diff(dayjs()));
       if (next !== interval) interval = next;
     }
   });

--- a/tests/AdaptiveIntervalBoundary.test.ts
+++ b/tests/AdaptiveIntervalBoundary.test.ts
@@ -1,0 +1,65 @@
+import { flushSync, mount, unmount } from "svelte";
+import Time from "svelte-time";
+
+describe("adaptive live interval at tier boundaries", () => {
+  let instances: ReturnType<typeof mount>[] = [];
+
+  afterEach(() => {
+    for (const instance of instances) {
+      unmount(instance);
+    }
+    instances = [];
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  test("does not enter an infinite update loop when shared clocks disagree about an hour boundary", () => {
+    vi.useFakeTimers();
+
+    const base = new Date("2026-08-11T12:00:00Z");
+    vi.setSystemTime(base);
+
+    // Activates the 5-minute shared clock with `now` cached at `base`.
+    instances.push(
+      mount(Time, {
+        target: document.body,
+        props: {
+          live: true,
+          relative: true,
+          timestamp: new Date(base.getTime() - 2 * 60 * 60 * 1_000),
+        },
+      }),
+    );
+    flushSync();
+
+    vi.setSystemTime(new Date(base.getTime() + 2_000));
+
+    // Activates the 30-second shared clock with `now` cached 2s after `base`.
+    instances.push(
+      mount(Time, {
+        target: document.body,
+        props: {
+          live: true,
+          relative: true,
+          timestamp: new Date(base.getTime() - 30 * 60 * 1_000),
+        },
+      }),
+    );
+    flushSync();
+
+    // Falls between the two shared clocks' views of the one-hour boundary.
+    expect(() => {
+      instances.push(
+        mount(Time, {
+          target: document.body,
+          props: {
+            live: true,
+            relative: true,
+            timestamp: new Date(base.getTime() - (60 * 60 * 1_000 - 1_000)),
+          },
+        }),
+      );
+      flushSync();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #107. When two shared adaptive clocks disagree about which
side of a tier boundary a timestamp falls on, the tier can flip
back and forth forever and throw effect_update_depth_exceeded.