### PR TITLE
fix: break adaptive live interval loop in Duration at tier boundaries

### DIFF
--- a/src/Duration.svelte
+++ b/src/Duration.svelte
@@ -82,7 +82,12 @@
 
   $effect(() => {
     if (since !== undefined && live === true) {
-      const next = liveInterval(dayjs(since).diff(now));
+      // Track `now` only to re-run on each tick of the shared clock; the
+      // tier decision itself uses a fresh, non-cached current time so it
+      // can't disagree with itself as `interval` switches which shared
+      // clock `now` reads from.
+      void now;
+      const next = liveInterval(dayjs(since).diff(dayjs()));
       if (next !== interval) interval = next;
     }
   });

--- a/tests/DurationAdaptiveIntervalBoundary.test.ts
+++ b/tests/DurationAdaptiveIntervalBoundary.test.ts
@@ -1,0 +1,62 @@
+import { flushSync, mount, unmount } from "svelte";
+import { Duration } from "svelte-time";
+
+describe("Duration adaptive live interval at tier boundaries", () => {
+  let instances: ReturnType<typeof mount>[] = [];
+
+  afterEach(() => {
+    for (const instance of instances) {
+      unmount(instance);
+    }
+    instances = [];
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  test("does not enter an infinite update loop when shared clocks disagree about an hour boundary", () => {
+    vi.useFakeTimers();
+
+    const base = new Date("2026-08-11T12:00:00Z");
+    vi.setSystemTime(base);
+
+    // Activates the 5-minute shared clock with `now` cached at `base`.
+    instances.push(
+      mount(Duration, {
+        target: document.body,
+        props: {
+          live: true,
+          since: new Date(base.getTime() - 2 * 60 * 60 * 1_000),
+        },
+      }),
+    );
+    flushSync();
+
+    vi.setSystemTime(new Date(base.getTime() + 2_000));
+
+    // Activates the 30-second shared clock with `now` cached 2s after `base`.
+    instances.push(
+      mount(Duration, {
+        target: document.body,
+        props: {
+          live: true,
+          since: new Date(base.getTime() - 30 * 60 * 1_000),
+        },
+      }),
+    );
+    flushSync();
+
+    // Falls between the two shared clocks' views of the one-hour boundary.
+    expect(() => {
+      instances.push(
+        mount(Duration, {
+          target: document.body,
+          props: {
+            live: true,
+            since: new Date(base.getTime() - (60 * 60 * 1_000 - 1_000)),
+          },
+        }),
+      );
+      flushSync();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Duration's adaptive live effect had the same shape as the Time.svelte
bug fixed in #108: it derived its next tier from the tier-selected
shared clock, which the effect itself writes, so two shared clocks
disagreeing about a boundary could flip the tier forever.